### PR TITLE
Fix dayoff same-day selection and hide weekends

### DIFF
--- a/discord_bot/views/day_off_slash.py
+++ b/discord_bot/views/day_off_slash.py
@@ -292,7 +292,7 @@ class DayOffView_slash(discord.ui.View):
         else:
             # For this week
             days_ahead = day_number - current_weekday
-            if days_ahead <= 0 and "day_off_thisweek" in self.cmd_or_step:
+            if days_ahead < 0 and "day_off_thisweek" in self.cmd_or_step:
                 # If the day has passed this week and it's thisweek command,
                 # we shouldn't include it (this is a safety check)
                 return None
@@ -347,9 +347,7 @@ def create_day_off_view(
         "Вівторок",
         "Середа",
         "Четвер",
-        "П'ятниця",
-        "Субота",
-        "Неділя"
+        "П'ятниця"
     ]
     
     for day in days:


### PR DESCRIPTION
## Summary
- remove Saturday and Sunday buttons for the dayoff slash command
- allow selecting the current day so the date is returned

## Testing
- `python -m py_compile discord_bot/views/day_off_slash.py`


------
https://chatgpt.com/codex/tasks/task_e_684fd6d63ac48331922ea761eff8c507