### PR TITLE
docs: clarify migration tasks

### DIFF
--- a/n8nTasks/Task01_NotionConnector.md
+++ b/n8nTasks/Task01_NotionConnector.md
@@ -5,10 +5,13 @@ Implement a reusable async wrapper around the Notion REST API. The existing
 workflow only **queries** databases and **updates** properties on existing
 pages; it never creates new ones. The connector should expose helpers that
 replace n8n's Notion nodes.
+Database IDs such as the Team Directory, Workload, and Profile Stats must be
+supplied via configuration or environment variables rather than hardcoded
+inside the connector.
 
 ## Supported operations
 1. **Team Directory lookups**
-   - find by employee name
+   - find a page by the `Name` property
    - find by Discord channel ID
    - update a page with Discord user ID and channel ID
 2. **Workload database**

--- a/n8nTasks/Task02_CalendarConnector.md
+++ b/n8nTasks/Task02_CalendarConnector.md
@@ -2,6 +2,8 @@
 
 ## Goal
 Implement an async client for the calendar service so handlers can create day-off and vacation events without n8n.
+The target calendar ID must be provided via configuration or environment
+variables rather than hardcoded.
 
 ## Supported operations
 1. **Create day-off event**
@@ -49,6 +51,9 @@ Failure template for any operation:
 def base_headers():
     token = os.environ["CALENDAR_TOKEN"]
     return {"Authorization": f"Bearer {token}"}
+
+CALENDAR_ID = os.environ["CALENDAR_ID"]
+CALENDAR_URL = f"https://www.googleapis.com/calendar/v3/calendars/{CALENDAR_ID}/events"
 
 async def create_event(summary, start, end):
     payload = {"summary": summary, "start": start, "end": end}

--- a/n8nTasks/Task03_SurveyStepsDB.md
+++ b/n8nTasks/Task03_SurveyStepsDB.md
@@ -8,6 +8,8 @@ Store survey progress so the bot can skip completed steps and query missed ones 
    - insert or update a row keyed by `(session_id, step_name)`
 2. **Fetch last week’s statuses**
    - return the most recent record per step for a session
+3. **Determine pending steps**
+   - given expected step names, return those not completed for the current week
 
 ## Schema
 The `n8n_survey_steps_missed` table already exists in production, so no migration is
@@ -83,6 +85,11 @@ async def fetch_week(session_id, week_start):
         session_id, week_start,
     )
     return [dict(r) for r in rows]
+
+async def pending_steps(session_id, week_start, all_steps):
+    records = await fetch_week(session_id, week_start)
+    done = {r["step_name"] for r in records if r["completed"]}
+    return [s for s in all_steps if s not in done]
 ```
 
 ## Testing

--- a/n8nTasks/Task04_InternalDispatcher.md
+++ b/n8nTasks/Task04_InternalDispatcher.md
@@ -1,7 +1,7 @@
 # Task 04: Internal webhook dispatcher
 
 ## Goal
-Replace the external n8n webhook call with an internal router that routes payloads to Python handlers, distinguishing between standalone commands, mention queries, and survey steps.
+Replace the external n8n webhook call with an internal router that routes payloads to Python handlers, distinguishing between standalone commands, mention queries, and survey steps. The router reproduces the n8n AI Agent's routing decisions but does not attempt to replace the underlying language model.
 
 ## Steps
 1. Use the Notion connector to look up the channel in the Team Directory (`payload["channelId"]`) and enrich the payload with the user's name, Discord ID, and to-do URL. Example lookup result:
@@ -15,17 +15,18 @@ Replace the external n8n webhook call with an internal router that routes payloa
      "to_do": "https://www.notion.so/11cc3573e5108104a0f1d579c3f9a648"
    }
    ```
-2. Create a `router` module with a registry mapping command names to handler coroutines (e.g., `register`, `mention`). Survey steps reuse these same handlers.
-3. Modify `services/webhook.py` so `send_webhook` builds the payload and forwards it to `router.dispatch` instead of performing an HTTP request.
-4. Inside `router.dispatch`, determine whether the payload is part of an active survey:
+2. Apply the workflow's "Check register" rules before registration: if the Team Directory record has `is_public == true`, return a message that public channels cannot be registered. If a 19‑digit `Discord channel ID` already exists, return the "channel already registered" message. Proceed only when neither condition applies.
+3. Create a `router` module with a registry mapping command names to handler coroutines (e.g., `register`, `mention`). Survey steps reuse these same handlers.
+4. Modify `services/webhook.py` so `send_webhook` builds the payload and forwards it to `router.dispatch` instead of performing an HTTP request.
+5. Inside `router.dispatch`, determine whether the payload is part of an active survey. The survey manager relies on the Survey Steps database to determine which steps remain:
    - If `payload["command"] == "survey"` or `survey_manager.is_active(payload["userId"])`, treat it as a survey step and use `payload["result"]["stepName"]` to select the handler.
    - If `payload["type"] == "mention"`, route directly to the mention handler.
    - Otherwise, treat it as a standalone command and use `payload["command"]`.
-5. After invoking the handler, wrap its result:
+6. After invoking the handler, wrap its result:
    - For survey steps, include survey metadata (`status`, `next_step`) along with the handler's output. Append the `user.to_do` URL retrieved in step 1 when the survey ends.
    - For standalone commands and mentions, return only the handler's output.
-6. Implement a `handle_mention` helper that returns the placeholder message defined in `n8n-workflow.json`.
-7. Ensure the dispatcher returns the same response structure currently produced by n8n.
+7. Implement a `handle_mention` helper that returns the placeholder message defined in `n8n-workflow.json`.
+8. Ensure the dispatcher returns the same response structure currently produced by n8n.
 
 ### Input Variants
 - **Standalone command** – `payload["command"]` matches a handler name such as `register` or `workload_today`.

--- a/n8nTasks/Task08_WorkloadTodayHandler.md
+++ b/n8nTasks/Task08_WorkloadTodayHandler.md
@@ -5,7 +5,9 @@ Implement `handle_workload_today` so the router can record today's workload dire
 
 ## Business Logic
 - Extract `hours` from the payload and treat `0` as a valid value.
-- Fetch the user's workload page URL and stats from Notion using their name.
+- Fetch the user's workload page URL and stats from Notion using their name,
+  retrieving both current `Fact` and weekly `Capacity` values for the
+  response template.
 - Determine the correct `day_field` (e.g., `Mon Plan`) for today's date.
 - Write the hours to Notion and mark the `workload_today` survey step as completed.
 - On any Notion failure return the generic error message.

--- a/n8nTasks/Task10_ConnectsThisWeekHandler.md
+++ b/n8nTasks/Task10_ConnectsThisWeekHandler.md
@@ -5,7 +5,7 @@ Implement `handle_connects_thisweek` so the router records remaining Upwork conn
 
 ## Business Logic
 - Pull the numeric connects value from the payload and mark the `connects_thisweek` survey step complete.
-- Send the value to the connects database with an HTTP `POST` request to `https://tech2.etcetera.kiev.ua/set-db-connects` using body `{ "name": <user>, "connects": <count> }`.
+- Send the value to the connects database with an HTTP `POST` request to a configurable endpoint (default `https://tech2.etcetera.kiev.ua/set-db-connects`) using body `{ "name": <user>, "connects": <count> }`.
 - If a profile stats page exists, write the connects value to it, ignoring failures.
 - Any failure in these operations returns the generic error message.
 
@@ -67,14 +67,17 @@ Implement `handle_connects_thisweek` so the router records remaining Upwork conn
 
 ## Pseudocode
 ```python
+import os
+
 async def handle_connects_thisweek(payload):
     try:
         connects = int(payload["result"]["connects"])
         await survey.mark_step(payload["userId"], "connects_thisweek")
-        await http.post(
-            "https://tech2.etcetera.kiev.ua/set-db-connects",
-            json={"name": payload["author"], "connects": connects},
-        )
+         connects_url = os.environ.get("CONNECTS_URL", "https://tech2.etcetera.kiev.ua/set-db-connects")
+         await http.post(
+             connects_url,
+             json={"name": payload["author"], "connects": connects},
+         )
         stats = await notion.get_profile_stats(payload["author"])
         if stats:
             try:

--- a/n8nTasks/Task11_DayOffHandler.md
+++ b/n8nTasks/Task11_DayOffHandler.md
@@ -12,6 +12,7 @@ Implement `handle_day_off` to record days off for either the current or upcoming
 - When the user selects `"Nothing"`, skip calendar writes and mark the step complete.
 - Mark the corresponding survey step (`day_off_thisweek` or `day_off_nextweek`) as completed.
 - Choose response template based on whether zero, one, or many dates were provided and whether the command targeted this week or next week.
+- Format dates in responses using a helper that outputs `DD MMMM YY`.
 - Any calendar failure returns the generic error message.
 
 ### Input Variants
@@ -48,7 +49,7 @@ Implement `handle_day_off` to record days off for either the current or upcoming
 2. If the value is `"Nothing"` or an empty list, mark the step and return the "no dates" template.
 3. Otherwise, call `calendar.create_event("Day-off: {user.name}", day, day)` for each date.
 4. Mark the survey step complete.
-5. Choose the one-date or many-date template and return it.
+5. Choose the one-date or many-date template, formatting dates as `DD MMMM YY`, and return it.
 6. On calendar failure, return the error message.
 
 ## Pseudocode

--- a/n8nTasks/Task12_VacationHandler.md
+++ b/n8nTasks/Task12_VacationHandler.md
@@ -10,7 +10,8 @@ Implement `handle_vacation` so users can log vacations directly through the bot.
   - `start`: `"{start_date} 00:00:00"`
   - `end`:   `"{end_date} 23:59:59"`
   and mark `vacation` as completed.
-- Respond with a summary of the scheduled vacation.
+- Respond with a summary of the scheduled vacation, formatting dates as
+  `WEEKDAY DD MMMM` using a date utility.
 - Any calendar failure returns the generic error message.
 
 ### Input Variants
@@ -45,7 +46,7 @@ Implement `handle_vacation` so users can log vacations directly through the bot.
 1. Extract start and end dates from `payload["result"]`.
 2. Call `calendar.create_event("Vacation: {user.name}", f"{start_date} 00:00:00", f"{end_date} 23:59:59")`.
 3. Mark the survey step complete if part of a survey.
-4. Return a confirmation or error message using the vacation template.
+4. Format the dates for the template and return a confirmation or error message using the vacation template.
 
 ## Pseudocode
 ```python

--- a/n8nTasks/Task13_CheckChannelHandler.md
+++ b/n8nTasks/Task13_CheckChannelHandler.md
@@ -1,10 +1,10 @@
 # Task 13: Check Channel Handler
 
 ## Goal
-Implement `handle_check_channel` to verify that the current channel is registered and ready for surveys.
+Implement `handle_check_channel` to verify that the current channel is registered and ready for surveys. This handler is invoked internally (`author` is `"system"`) to ensure a channel has a Team Directory entry before user interactions begin.
 
 ## Business Logic
-- Use `channelId` to search for an existing channel record in Notion.
+- Triggered as a system check, it uses `channelId` to search for an existing channel record in Notion.
 - Each entry exposes `Name`, `Discord ID`, `Discord channel ID`, and `ToDo` properties.
 - If a record exists, return its assigned user name.
 - If missing, create the channel entry with default survey configuration and acknowledge the registration.


### PR DESCRIPTION
## Summary
- note that Notion and calendar IDs should come from config
- document pending survey-step logic and registration checks
- refine handler specs for date formatting and configurable endpoints
- restore logging task to original spec without n8n execution ID

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c00a2968b88331a7b821980aef684a