### PR TITLE
Add async Notion connector and tests

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -13,6 +13,12 @@ class Config:
     # N8N webhook configuration
     N8N_WEBHOOK_URL: str = os.getenv("N8N_WEBHOOK_URL", "")
     WEBHOOK_AUTH_TOKEN: Optional[str] = os.getenv("WEBHOOK_AUTH_TOKEN")
+
+    # Notion configuration
+    NOTION_TOKEN: str = os.getenv("NOTION_TOKEN", "")
+    NOTION_TEAM_DIRECTORY_DB_ID: str = os.getenv("NOTION_TEAM_DIRECTORY_DB_ID", "")
+    NOTION_WORKLOAD_DB_ID: str = os.getenv("NOTION_WORKLOAD_DB_ID", "")
+    NOTION_PROFILE_STATS_DB_ID: str = os.getenv("NOTION_PROFILE_STATS_DB_ID", "")
     
     # Session configuration
     SESSION_TTL: int = int(os.getenv("SESSION_TTL", "86400"))  # 24 hours default

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.0.1
 cachetools==5.3.3
 pytz==2024.1
 notion-client
+pytest-asyncio

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,6 +1,7 @@
 from services.session import session_manager
 from services.survey import survey_manager, SurveyFlow
 from services.webhook import webhook_service, HttpSession, WebhookError
+from services.notion_connector import NotionConnector, NotionError
 
 __all__ = [
     'session_manager',
@@ -8,5 +9,7 @@ __all__ = [
     'SurveyFlow',
     'webhook_service',
     'HttpSession',
-    'WebhookError'
-] 
+    'WebhookError',
+    'NotionConnector',
+    'NotionError'
+]

--- a/services/notion_connector.py
+++ b/services/notion_connector.py
@@ -1,0 +1,186 @@
+"""Async Notion connector used to replace n8n Notion nodes.
+
+Pseudocode from Task01_NotionConnector.md::
+
+    def base_headers():
+        token = os.environ["NOTION_TOKEN"]
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28",
+        }
+
+    async def query_database(database_id, filter):
+        url = f"https://api.notion.com/v1/databases/{database_id}/query"
+        async with aiohttp.post(url, headers=base_headers(), json={"filter": filter}) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise NotionError(data)
+            return normalize_query(data)
+
+    async def update_page(page_id, properties):
+        url = f"https://api.notion.com/v1/pages/{page_id}"
+        async with aiohttp.patch(url, headers=base_headers(), json={"properties": properties}) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise NotionError(data)
+            return {"status": "ok"}
+
+The implementation below follows this design and adds helpers for the Team
+Directory, Workload, and Profile Stats databases. Database IDs are supplied via
+environment variables or ``config.Config`` values.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+from config import Config
+
+
+class NotionError(Exception):
+    """Raised when the Notion API returns a non-successful response."""
+
+
+def base_headers() -> Dict[str, str]:
+    """Return headers required for all Notion API requests."""
+
+    token = os.environ.get("NOTION_TOKEN", Config.NOTION_TOKEN)
+    if not token:
+        raise NotionError("NOTION_TOKEN is not configured")
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Notion-Version": "2022-06-28",
+    }
+
+
+def _extract_property(prop: Dict[str, Any], field_name: str) -> Any:
+    """Extract a value from a Notion property block."""
+
+    if not prop:
+        return ""
+    if "title" in prop:
+        return "".join(t.get("plain_text", "") for t in prop["title"])
+    if "rich_text" in prop:
+        texts = prop["rich_text"]
+        if field_name == "to_do":
+            for t in texts:
+                if t.get("href"):
+                    return t["href"].strip()
+                text = t.get("plain_text", "").strip()
+                if text.startswith("http"):
+                    return text
+        return "".join(t.get("plain_text", "") for t in texts)
+    if "number" in prop:
+        return prop.get("number") or 0
+    return ""
+
+
+def normalize_query(data: Dict[str, Any], mapping: Dict[str, str]) -> Dict[str, Any]:
+    """Normalize Notion query results using a property mapping."""
+
+    results = []
+    for item in data.get("results", []):
+        props = item.get("properties", {})
+        normalized = {
+            "id": item.get("id", ""),
+            "url": item.get("url", ""),
+        }
+        for out_name, prop_name in mapping.items():
+            normalized[out_name] = _extract_property(props.get(prop_name, {}), out_name)
+        results.append(normalized)
+    return {"status": "ok", "results": results}
+
+
+class NotionConnector:
+    """Asynchronous wrapper around the Notion REST API."""
+
+    def __init__(self, session: Optional[aiohttp.ClientSession] = None) -> None:
+        self.session = session
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self.session is None or getattr(self.session, "closed", False):
+            self.session = aiohttp.ClientSession()
+        return self.session
+
+    async def close(self) -> None:
+        if self.session and not getattr(self.session, "closed", False):
+            await self.session.close()
+
+    async def query_database(
+        self,
+        database_id: str,
+        filter: Dict[str, Any],
+        mapping: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Query a Notion database and return normalized results."""
+
+        session = await self._get_session()
+        url = f"https://api.notion.com/v1/databases/{database_id}/query"
+        async with session.post(url, headers=base_headers(), json={"filter": filter}) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise NotionError(data)
+        return normalize_query(data, mapping or {})
+
+    async def update_page(self, page_id: str, properties: Dict[str, Any]) -> Dict[str, str]:
+        """Update properties on a Notion page."""
+
+        session = await self._get_session()
+        url = f"https://api.notion.com/v1/pages/{page_id}"
+        async with session.patch(url, headers=base_headers(), json={"properties": properties}) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise NotionError(data)
+        return {"status": "ok"}
+
+    # --- Helper methods for specific databases ---
+
+    async def find_team_directory_by_channel(self, channel_id: str) -> Dict[str, Any]:
+        filter = {
+            "property": "Discord channel ID",
+            "rich_text": {"contains": channel_id},
+        }
+        mapping = {
+            "name": "Name",
+            "discord_id": "Discord ID",
+            "channel_id": "Discord channel ID",
+            "to_do": "ToDo",
+        }
+        return await self.query_database(Config.NOTION_TEAM_DIRECTORY_DB_ID, filter, mapping)
+
+    async def update_team_directory_ids(
+        self, page_id: str, discord_id: str, channel_id: str
+    ) -> Dict[str, str]:
+        properties = {
+            "Discord ID": {"rich_text": [{"text": {"content": discord_id}}]},
+            "Discord channel ID": {"rich_text": [{"text": {"content": channel_id}}]},
+        }
+        return await self.update_page(page_id, properties)
+
+    async def get_workload_page_by_name(self, name: str) -> Dict[str, Any]:
+        filter = {"property": "Name", "title": {"equals": name}}
+        mapping = {"name": "Name"}
+        return await self.query_database(Config.NOTION_WORKLOAD_DB_ID, filter, mapping)
+
+    async def update_workload_day(
+        self, page_id: str, day_field: str, hours: float
+    ) -> Dict[str, str]:
+        properties = {day_field: {"number": hours}}
+        return await self.update_page(page_id, properties)
+
+    async def get_profile_stats_by_name(self, name: str) -> Dict[str, Any]:
+        filter = {"property": "Name", "title": {"equals": name}}
+        mapping = {"name": "Name", "connects": "Upwork connects"}
+        return await self.query_database(Config.NOTION_PROFILE_STATS_DB_ID, filter, mapping)
+
+    async def update_profile_stats_connects(
+        self, page_id: str, connects: int
+    ) -> Dict[str, str]:
+        properties = {"Upwork connects": {"number": connects}}
+        return await self.update_page(page_id, properties)
+

--- a/tests/test_notion_connector.py
+++ b/tests/test_notion_connector.py
@@ -1,0 +1,126 @@
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+# Add project and services directories to import path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "services"))
+
+from notion_connector import NotionConnector
+from config.config import Config
+
+
+class MockResponse:
+    """Simple mock for aiohttp response."""
+
+    def __init__(self, status: int, data: Dict[str, Any]):
+        self.status = status
+        self._data = data
+
+    async def json(self) -> Dict[str, Any]:
+        return self._data
+
+    async def __aenter__(self) -> "MockResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class DummySession:
+    """Session that records calls and returns predefined responses."""
+
+    def __init__(self) -> None:
+        self.post_calls: List[Tuple[str, Dict[str, str], Dict[str, Any]]] = []
+        self.patch_calls: List[Tuple[str, Dict[str, str], Dict[str, Any]]] = []
+        self.post_response: MockResponse | None = None
+        self.patch_response: MockResponse | None = None
+        self.closed = False
+
+    def post(self, url: str, headers: Dict[str, str], json: Dict[str, Any]):
+        self.post_calls.append((url, headers, json))
+        return self.post_response
+
+    def patch(self, url: str, headers: Dict[str, str], json: Dict[str, Any]):
+        self.patch_calls.append((url, headers, json))
+        return self.patch_response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_query_database_normalizes(tmp_path):
+    log_file = tmp_path / "query_log.txt"
+    log_file.write_text("Input: channel_id=1234567890\n")
+
+    os.environ["NOTION_TOKEN"] = "token"
+    Config.NOTION_TEAM_DIRECTORY_DB_ID = "TD_DB"
+
+    session = DummySession()
+    response_data = {
+        "results": [
+            {
+                "id": "PAGE_ID",
+                "url": "https://www.notion.so/Roman-Lernichenko-b02bf04c43e4404ca4e21707ae8b61cc",
+                "properties": {
+                    "Name": {"title": [{"plain_text": "Roman Lernichenko"}]},
+                    "Discord ID": {"rich_text": []},
+                    "Discord channel ID": {"rich_text": []},
+                    "ToDo": {
+                        "rich_text": [
+                            {
+                                "plain_text": "Todo - Roman Lernichenko",
+                                "href": "https://www.notion.so/11cc3573e5108104a0f1d579c3f9a648",
+                            }
+                        ]
+                    },
+                },
+            }
+        ]
+    }
+    session.post_response = MockResponse(200, response_data)
+
+    connector = NotionConnector(session=session)
+
+    result = await connector.find_team_directory_by_channel("1234567890")
+    with open(log_file, "a") as f:
+        f.write("Step: called find_team_directory_by_channel\n")
+        f.write(f"Output: {result}\n")
+
+    assert session.post_calls
+    url, headers, payload = session.post_calls[0]
+    assert url == "https://api.notion.com/v1/databases/TD_DB/query"
+    assert headers["Authorization"] == "Bearer token"
+    assert payload["filter"]["rich_text"]["contains"] == "1234567890"
+    assert result["results"][0]["name"] == "Roman Lernichenko"
+
+
+@pytest.mark.asyncio
+async def test_update_page_success(tmp_path):
+    log_file = tmp_path / "update_log.txt"
+    log_file.write_text("Input: page_id=PAGE_ID, discord_id=321, channel_id=1234567890\n")
+
+    os.environ["NOTION_TOKEN"] = "token"
+
+    session = DummySession()
+    session.patch_response = MockResponse(200, {"object": "page"})
+
+    connector = NotionConnector(session=session)
+
+    result = await connector.update_team_directory_ids("PAGE_ID", "321", "1234567890")
+    with open(log_file, "a") as f:
+        f.write("Step: called update_team_directory_ids\n")
+        f.write(f"Output: {result}\n")
+
+    assert session.patch_calls
+    url, headers, payload = session.patch_calls[0]
+    assert url == "https://api.notion.com/v1/pages/PAGE_ID"
+    assert headers["Authorization"] == "Bearer token"
+    assert payload["properties"]["Discord ID"]["rich_text"][0]["text"]["content"] == "321"
+    assert result == {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add Config settings and async Notion connector for querying/updating databases
- expose helper methods for team directory, workload, and profile stats operations
- cover Notion connector with unit tests and logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c00fbb20588331a2121c9033e226f4