### PR TITLE
feat: implement unregister handler

### DIFF
--- a/n8nTasks/TaskList.md
+++ b/n8nTasks/TaskList.md
@@ -6,7 +6,7 @@
 - [ ] Task04_InternalDispatcher.md
 - [ ] Task05_PrefixCommands.md
 - [ ] Task06_RegisterHandler.md
-- [ ] Task07_UnregisterHandler.md
+- [x] Task07_UnregisterHandler.md
 - [ ] Task08_WorkloadTodayHandler.md
 - [ ] Task09_WorkloadNextWeekHandler.md
 - [ ] Task10_ConnectsThisWeekHandler.md

--- a/services/cmd/unregister.py
+++ b/services/cmd/unregister.py
@@ -1,6 +1,21 @@
 from typing import Any, Dict
 
+from services.notion_connector import NotionConnector
+
+_notio = NotionConnector()
+
 
 async def handle(payload: Dict[str, Any]) -> str:
-    """Placeholder handler for the unregister command."""
-    return "Команда unregister ще не реалізована."
+    channel_id = payload.get("channelId", "")
+    try:
+        data = await _notio.find_team_directory_by_channel(channel_id)
+        page = data.get("results", [])
+        if not page:
+            return (
+                "Вибачте, але цей канал не зареєстрований ні на кого. Тому не можу зняти його з реєстрації"
+            )
+        page_id = page[0]["id"]
+        await _notio.clear_team_directory_ids(page_id)
+        return "Готово. Тепер цей канал не зареєстрований ні на кого."
+    except Exception:
+        return "Спробуй трохи піздніше. Я тут пораюсь по хаті."

--- a/services/notion_connector.py
+++ b/services/notion_connector.py
@@ -194,6 +194,12 @@ class NotionConnector:
         }
         return await self.update_page(page_id, properties)
 
+    async def clear_team_directory_ids(self, page_id: str) -> Dict[str, str]:
+        """Remove the Discord channel association for a team directory entry."""
+
+        properties = {"Discord channel ID": {"rich_text": []}}
+        return await self.update_page(page_id, properties)
+
     async def get_workload_page_by_name(self, name: str) -> Dict[str, Any]:
         filter = {"property": "Name", "title": {"equals": name}}
         mapping = {"name": "Name"}

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -42,7 +42,18 @@ def load_notion_lookup():
     text = Path(ROOT / "responses").read_text()
     name = re.search(r'plain_text": "([^"]+Lernichenko)"', text).group(1)
     todo_url = re.search(r'https://www.notion.so/[0-9a-f-]+', text).group(0)
-    return {"results": [{"name": name, "discord_id": "321", "channel_id": "123", "to_do": todo_url}]}
+    page_id = re.search(r'id": "([0-9a-f-]{36})"', text).group(1)
+    return {
+        "results": [
+            {
+                "id": page_id,
+                "name": name,
+                "discord_id": "321",
+                "channel_id": "123",
+                "to_do": todo_url,
+            }
+        ]
+    }
 # Stub config to avoid heavy imports
 class DummyConfig:
     NOTION_TEAM_DIRECTORY_DB_ID = ""
@@ -58,6 +69,7 @@ sys.modules["config"] = types.SimpleNamespace(
 )
 
 import router
+from services.cmd import unregister as unregister_cmd
 
 survey_manager = router.survey_manager
 
@@ -201,6 +213,37 @@ async def test_dispatch_user_not_found(tmp_path, monkeypatch):
     with open(log, "a") as f:
         f.write(f"Output: {result}\n")
     assert result == {"output": "Користувач не знайдений"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unregister(tmp_path, monkeypatch):
+    log = tmp_path / "dispatch_unregister_log.txt"
+    payload = load_payload_example("!unregister Command Payload")
+    payload["channelId"] = "123"
+    log.write_text(f"Input: {payload}\n")
+
+    lookup = load_notion_lookup()
+    called = []
+
+    async def fake_find(channel_id):
+        return lookup
+
+    async def fake_clear(page_id):
+        called.append(page_id)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(router._notio, "find_team_directory_by_channel", fake_find)
+    monkeypatch.setattr(unregister_cmd._notio, "find_team_directory_by_channel", fake_find)
+    monkeypatch.setattr(unregister_cmd._notio, "clear_team_directory_ids", fake_clear)
+
+    with open(log, "a") as f:
+        f.write("Step: dispatch\n")
+    result = await router.dispatch(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {result}\n")
+
+    assert result == {"output": "Готово. Тепер цей канал не зареєстрований ні на кого."}
+    assert called == [lookup["results"][0]["id"]]
 
 
 def test_parse_prefix_register(tmp_path):

--- a/tests/test_unregister_handler.py
+++ b/tests/test_unregister_handler.py
@@ -1,0 +1,153 @@
+import sys
+import json
+import re
+from pathlib import Path
+import types
+import logging
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/cmd"))
+
+fake_google = types.ModuleType("google")
+auth = types.ModuleType("auth")
+transport = types.ModuleType("transport")
+requests_mod = types.ModuleType("requests")
+requests_mod.Request = object
+transport.requests = requests_mod
+auth.transport = transport
+oauth2 = types.ModuleType("oauth2")
+service_account = types.ModuleType("service_account")
+service_account.Credentials = object
+oauth2.service_account = service_account
+fake_google.auth = auth
+fake_google.oauth2 = oauth2
+sys.modules["google"] = fake_google
+sys.modules["google.auth"] = auth
+sys.modules["google.auth.transport"] = transport
+sys.modules["google.auth.transport.requests"] = requests_mod
+sys.modules["google.oauth2"] = oauth2
+sys.modules["google.oauth2.service_account"] = service_account
+
+
+class DummyConfig:
+    NOTION_TEAM_DIRECTORY_DB_ID = ""
+    NOTION_TOKEN = ""
+    NOTION_WORKLOAD_DB_ID = ""
+    NOTION_PROFILE_STATS_DB_ID = ""
+    N8N_WEBHOOK_URL = ""
+    WEBHOOK_AUTH_TOKEN = ""
+    SESSION_TTL = 1
+
+
+sys.modules["config"] = types.SimpleNamespace(
+    Config=DummyConfig, logger=logging.getLogger("test"), Strings=object()
+)
+
+import unregister
+
+
+def load_payload_example(title: str) -> dict:
+    text = (ROOT / "payload_examples.txt").read_text()
+    start = text.index(title)
+    match = re.search(r"```json\n(.*?)\n```", text[start:], re.DOTALL)
+    return json.loads(match.group(1))
+
+
+def load_notion_lookup() -> dict:
+    text = (ROOT / "responses").read_text()
+    name = re.search(r'plain_text": "([^"]+Lernichenko)"', text).group(1)
+    todo_url = re.search(r"https://www.notion.so/[0-9a-f-]+", text).group(0)
+    page_id = re.search(r'id": "([0-9a-f-]{36})"', text).group(1)
+    return {
+        "results": [
+            {
+                "id": page_id,
+                "name": name,
+                "discord_id": "321",
+                "channel_id": "123",
+                "to_do": todo_url,
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_unregister_success(tmp_path, monkeypatch):
+    log = tmp_path / "unregister_success_log.txt"
+    payload = load_payload_example("!unregister Command Payload")
+    log.write_text(f"Input: {payload}\n")
+
+    lookup = load_notion_lookup()
+    called = []
+
+    async def fake_find(channel_id):
+        return lookup
+
+    async def fake_clear(page_id):
+        called.append(page_id)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(unregister._notio, "find_team_directory_by_channel", fake_find)
+    monkeypatch.setattr(unregister._notio, "clear_team_directory_ids", fake_clear)
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    result = await unregister.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {result}\n")
+
+    assert result == "Готово. Тепер цей канал не зареєстрований ні на кого."
+    assert called == [lookup["results"][0]["id"]]
+
+
+@pytest.mark.asyncio
+async def test_unregister_channel_missing(tmp_path, monkeypatch):
+    log = tmp_path / "unregister_missing_log.txt"
+    payload = load_payload_example("!unregister Command Payload")
+    log.write_text(f"Input: {payload}\n")
+
+    async def fake_find(channel_id):
+        return {"results": []}
+
+    monkeypatch.setattr(unregister._notio, "find_team_directory_by_channel", fake_find)
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    result = await unregister.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {result}\n")
+
+    assert (
+        result
+        == "Вибачте, але цей канал не зареєстрований ні на кого. Тому не можу зняти його з реєстрації"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unregister_notion_error(tmp_path, monkeypatch):
+    log = tmp_path / "unregister_error_log.txt"
+    payload = load_payload_example("!unregister Command Payload")
+    log.write_text(f"Input: {payload}\n")
+
+    lookup = load_notion_lookup()
+
+    async def fake_find(channel_id):
+        return lookup
+
+    async def fake_clear(page_id):
+        raise Exception("fail")
+
+    monkeypatch.setattr(unregister._notio, "find_team_directory_by_channel", fake_find)
+    monkeypatch.setattr(unregister._notio, "clear_team_directory_ids", fake_clear)
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    result = await unregister.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {result}\n")
+
+    assert result == "Спробуй трохи піздніше. Я тут пораюсь по хаті."
+


### PR DESCRIPTION
## Summary
- add NotionConnector helper to clear Discord channel associations
- implement `!unregister` handler removing channel assignments
- test unregister scenarios with payloads and responses

## Testing
- `pytest tests/test_unregister_handler.py -q`
- `pytest tests/test_router.py::test_parse_prefix_unregister -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04570cebc83319010697f1f41712e