### PR TITLE
feat: implement workload today handler

### DIFF
--- a/tests/test_workload_today.py
+++ b/tests/test_workload_today.py
@@ -31,8 +31,22 @@ def load_workload_response() -> dict:
     )
     url = re.search(url_pattern, text).group(1)
     capacity = int(re.search(r'"Capacity": {[^}]*"number": ([0-9]+)', text).group(1))
-    fact = float(re.search(r'"Wed Fact": {[^}]*"number": ([0-9.]+)', text).group(1))
-    return {"status": "ok", "results": [{"id": page_id, "url": url, "capacity": capacity, "fact": fact}]}
+    mon_fact = float(re.search(r'"Mon Fact": {[^}]*"number": ([0-9.]+)', text).group(1))
+    tue_fact = float(re.search(r'"Tue Fact": {[^}]*"number": ([0-9.]+)', text).group(1))
+    wed_fact = float(re.search(r'"Wed Fact": {[^}]*"number": ([0-9.]+)', text).group(1))
+    return {
+        "status": "ok",
+        "results": [
+            {
+                "id": page_id,
+                "url": url,
+                "capacity": capacity,
+                "fact_0": mon_fact,
+                "fact_1": tue_fact,
+                "fact_2": wed_fact,
+            }
+        ],
+    }
 
 
 @pytest.mark.asyncio
@@ -60,7 +74,9 @@ async def test_handle_workload_today_success(tmp_path, monkeypatch):
 
     monkeypatch.setattr(workload_today._notio, "query_database", fake_query)
     monkeypatch.setattr(workload_today._notio, "update_workload_day", fake_update)
-    monkeypatch.setattr(workload_today, "_steps_db", types.SimpleNamespace(upsert_step=fake_upsert))
+    monkeypatch.setattr(
+        workload_today, "_steps_db", types.SimpleNamespace(upsert_step=fake_upsert)
+    )
 
     result = await workload_today.handle(payload)
 
@@ -76,9 +92,29 @@ async def test_handle_workload_today_success(tmp_path, monkeypatch):
     assert called["hours"] == int(payload["result"]["value"])
     assert called["db"] == (payload["channelId"], "workload_today", True)
 
-    day_acc = ["понеділок", "вівторок", "середу", "четвер", "п'ятницю", "суботу", "неділю"][idx]
-    day_gen = ["понеділка", "вівторка", "середи", "четверга", "п'ятниці", "суботи", "неділі"][idx]
-    fact = int(resp["results"][0]["fact"])
+    day_acc = [
+        "понеділок",
+        "вівторок",
+        "середу",
+        "четвер",
+        "п'ятницю",
+        "суботу",
+        "неділю",
+    ][idx]
+    day_gen = [
+        "понеділка",
+        "вівторка",
+        "середи",
+        "четверга",
+        "п'ятниці",
+        "суботи",
+        "неділі",
+    ][idx]
+    fact = int(
+        resp["results"][0]["fact_0"]
+        + resp["results"][0]["fact_1"]
+        + resp["results"][0]["fact_2"]
+    )
     capacity = int(resp["results"][0]["capacity"])
     hours = int(payload["result"]["value"])
     expected = (
@@ -119,6 +155,29 @@ async def test_handle_workload_today_error(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_handle_workload_today_user_not_found(tmp_path, monkeypatch):
+    payload = load_payload_example("Workload Slash Command Payload")
+    payload.update({"channelId": "123", "author": "Tester"})
+    log = tmp_path / "workload_today_not_found.txt"
+    log.write_text(f"Input: {payload}\n")
+
+    async def fake_query(db_id, flt, mapping):
+        return {"status": "ok", "results": []}
+
+    monkeypatch.setattr(workload_today._notio, "query_database", fake_query)
+    monkeypatch.setattr(workload_today._notio, "update_workload_day", lambda *a, **k: None)
+    monkeypatch.setattr(workload_today, "_steps_db", None)
+
+    result = await workload_today.handle(payload)
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+        f.write(f"Output: {result}\n")
+
+    assert result == "Спробуй трохи піздніше. Я тут пораюсь по хаті."
+
+
+@pytest.mark.asyncio
 async def test_workload_today_e2e(tmp_path, monkeypatch):
     payload = load_payload_example("Workload Slash Command Payload")
     payload.update({"userId": "321", "channelId": "123", "sessionId": "123_321"})
@@ -129,7 +188,16 @@ async def test_workload_today_e2e(tmp_path, monkeypatch):
         text = (ROOT / "responses").read_text()
         name = re.search(r'plain_text": "([^"]+Lernichenko)"', text).group(1)
         todo_url = re.search(r'https://www.notion.so/[0-9a-f-]+', text).group(0)
-        return {"results": [{"name": name, "discord_id": "321", "channel_id": "123", "to_do": todo_url}]}
+        return {
+            "results": [
+                {
+                    "name": name,
+                    "discord_id": "321",
+                    "channel_id": "123",
+                    "to_do": todo_url,
+                }
+            ]
+        }
 
     async def fake_lookup(channel_id):
         return load_lookup()
@@ -142,13 +210,17 @@ async def test_workload_today_e2e(tmp_path, monkeypatch):
     async def fake_update(page_id, day_field, hours):
         return {"status": "ok"}
 
+    async def fake_upsert(*a, **k):
+        return None
+
     monkeypatch.setattr(router._notio, "find_team_directory_by_channel", fake_lookup)
     monkeypatch.setattr(workload_today._notio, "query_database", fake_query)
     monkeypatch.setattr(workload_today._notio, "update_workload_day", fake_update)
-    async def fake_upsert(*args, **kwargs):
-        return None
-
-    monkeypatch.setattr(workload_today, "_steps_db", types.SimpleNamespace(upsert_step=fake_upsert))
+    monkeypatch.setattr(
+        workload_today,
+        "_steps_db",
+        types.SimpleNamespace(upsert_step=fake_upsert),
+    )
 
     result = await router.dispatch(payload)
 
@@ -158,9 +230,29 @@ async def test_workload_today_e2e(tmp_path, monkeypatch):
 
     dt = datetime.fromtimestamp(payload["timestamp"], timezone.utc)
     idx = dt.weekday()
-    day_acc = ["понеділок", "вівторок", "середу", "четвер", "п'ятницю", "суботу", "неділю"][idx]
-    day_gen = ["понеділка", "вівторка", "середи", "четверга", "п'ятниці", "суботи", "неділі"][idx]
-    fact = int(resp["results"][0]["fact"])
+    day_acc = [
+        "понеділок",
+        "вівторок",
+        "середу",
+        "четвер",
+        "п'ятницю",
+        "суботу",
+        "неділю",
+    ][idx]
+    day_gen = [
+        "понеділка",
+        "вівторка",
+        "середи",
+        "четверга",
+        "п'ятниці",
+        "суботи",
+        "неділі",
+    ][idx]
+    fact = int(
+        resp["results"][0]["fact_0"]
+        + resp["results"][0]["fact_1"]
+        + resp["results"][0]["fact_2"]
+    )
     capacity = int(resp["results"][0]["capacity"])
     hours = int(payload["result"]["value"])
     expected = (
@@ -170,3 +262,4 @@ async def test_workload_today_e2e(tmp_path, monkeypatch):
         f"Капасіті на цей тиждень: {capacity} год."
     )
     assert result == {"output": expected}
+


### PR DESCRIPTION
## Summary
- handle workload_today command by writing plan hours to Notion and logging survey progress
- test workload_today success, failure, and router dispatch scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04575cf6883318be19fa456a1edb3