### PR TITLE
feat: add connects this week handler

### DIFF
--- a/services/cmd/connects_this_week.py
+++ b/services/cmd/connects_this_week.py
@@ -1,6 +1,61 @@
+"""Handler for recording remaining Upwork connects for the week."""
+
+from __future__ import annotations
+
+import os
 from typing import Any, Dict
+
+import aiohttp
+
+from config import Config
+from services.notion_connector import NotionConnector
+
+try:  # pragma: no cover - optional dependency
+    from services.survey_steps_db import SurveyStepsDB
+except Exception:  # pragma: no cover - missing databases package
+    SurveyStepsDB = None  # type: ignore
+
+
+ERROR_MESSAGE = "Спробуй трохи піздніше. Я тут пораюсь по хаті."
 
 
 async def handle(payload: Dict[str, Any]) -> str:
-    """Placeholder handler for the connects_this_week command."""
-    return "Команда connects_this_week ще не реалізована."
+    """Record weekly connects and update optional profile stats."""
+    try:
+        connects = int(payload["result"]["connects"])
+
+        # mark survey step as completed using channel id as session id
+        if SurveyStepsDB and Config.DATABASE_URL:
+            db = SurveyStepsDB(Config.DATABASE_URL)
+            try:
+                await db.upsert_step(payload["channelId"], "connects_thisweek", True)
+            finally:
+                await db.close()
+
+        # post connects count to external database
+        url = os.environ.get(
+            "CONNECTS_URL", "https://tech2.etcetera.kiev.ua/set-db-connects"
+        )
+        async with aiohttp.ClientSession() as session:
+            await session.post(
+                url, json={"name": payload["author"], "connects": connects}
+            )
+
+        # update profile stats in notion if page exists
+        notion = NotionConnector()
+        stats = await notion.get_profile_stats_by_name(payload["author"])
+        results = stats.get("results", []) if isinstance(stats, dict) else []
+        if results:
+            page_id = results[0].get("id")
+            try:
+                await notion.update_profile_stats_connects(page_id, connects)
+            except Exception:  # pragma: no cover - best effort
+                pass
+        await notion.close()
+
+        return (
+            f"Записав! Upwork connects: залишилось {connects} на цьому тиждні."
+        )
+    except Exception:
+        return ERROR_MESSAGE
+

--- a/tests/test_connects_this_week.py
+++ b/tests/test_connects_this_week.py
@@ -1,0 +1,178 @@
+import json
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "services" / "cmd"))
+
+import connects_this_week
+
+# Load payload examples and responses once
+payload_text = (ROOT / "payload_examples.txt").read_text()
+responses_text = (ROOT / "responses").read_text()
+
+# Extract the connects_thisweek command payload
+match = re.search(
+    r"/connects_thisweek Command Payload\n\n```json\n(\{.*?\})\n```",
+    payload_text,
+    re.S,
+)
+COMMAND_PAYLOAD = json.loads(match.group(1))
+# command in code uses underscores
+COMMAND_PAYLOAD["command"] = "connects_this_week"
+
+# Extract sample Notion page id and url from responses
+page_id_match = re.search(r'"id":\s*"([0-9a-f-]{36})"', responses_text)
+page_url_match = re.search(r"https://www.notion.so/[^\"]+", responses_text)
+PAGE_ID = page_id_match.group(1)
+PAGE_URL = page_url_match.group(0)
+SAMPLE_PROFILE = {"results": [{"id": PAGE_ID, "url": PAGE_URL}]}
+
+
+class DummySession:
+    def __init__(self, should_fail=False):
+        self.should_fail = should_fail
+        self.post_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def post(self, url, json):
+        self.post_calls.append((url, json))
+        if self.should_fail:
+            raise Exception("post failed")
+
+
+class FakeDB:
+    def __init__(self, *_):
+        self.upsert_step_calls = []
+
+    async def upsert_step(self, session_id, step, completed):
+        self.upsert_step_calls.append((session_id, step, completed))
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_profile_exists(monkeypatch, tmp_path):
+    log_file = tmp_path / "profile_exists_log.txt"
+    log_file.write_text(f"Input: {COMMAND_PAYLOAD}\n")
+
+    session = DummySession()
+    monkeypatch.setattr(connects_this_week.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setattr(connects_this_week, "Config", SimpleNamespace(DATABASE_URL="sqlite://"))
+
+    fake_notion = SimpleNamespace(
+        get_profile_stats_by_name=AsyncMock(return_value=SAMPLE_PROFILE),
+        update_profile_stats_connects=AsyncMock(),
+        close=AsyncMock(),
+    )
+    monkeypatch.setattr(connects_this_week, "NotionConnector", lambda: fake_notion)
+    monkeypatch.setattr(connects_this_week, "SurveyStepsDB", FakeDB)
+
+    result = await connects_this_week.handle(COMMAND_PAYLOAD)
+
+    with open(log_file, "a") as f:
+        f.write("Step: handle called\n")
+        f.write(f"Output: {result}\n")
+
+    expected = (
+        "Записав! Upwork connects: залишилось "
+        f"{COMMAND_PAYLOAD['result']['connects']} на цьому тиждні."
+    )
+    assert result == expected
+    assert fake_notion.update_profile_stats_connects.called
+
+
+@pytest.mark.asyncio
+async def test_no_profile(monkeypatch, tmp_path):
+    log_file = tmp_path / "no_profile_log.txt"
+    log_file.write_text(f"Input: {COMMAND_PAYLOAD}\n")
+
+    session = DummySession()
+    monkeypatch.setattr(connects_this_week.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setattr(connects_this_week, "Config", SimpleNamespace(DATABASE_URL="sqlite://"))
+
+    fake_notion = SimpleNamespace(
+        get_profile_stats_by_name=AsyncMock(return_value={"results": []}),
+        update_profile_stats_connects=AsyncMock(),
+        close=AsyncMock(),
+    )
+    monkeypatch.setattr(connects_this_week, "NotionConnector", lambda: fake_notion)
+    monkeypatch.setattr(connects_this_week, "SurveyStepsDB", FakeDB)
+
+    result = await connects_this_week.handle(COMMAND_PAYLOAD)
+
+    with open(log_file, "a") as f:
+        f.write("Step: handle called\n")
+        f.write(f"Output: {result}\n")
+
+    assert not fake_notion.update_profile_stats_connects.called
+
+
+@pytest.mark.asyncio
+async def test_database_error(monkeypatch, tmp_path):
+    log_file = tmp_path / "db_error_log.txt"
+    log_file.write_text(f"Input: {COMMAND_PAYLOAD}\n")
+
+    session = DummySession(should_fail=True)
+    monkeypatch.setattr(connects_this_week.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setattr(connects_this_week, "Config", SimpleNamespace(DATABASE_URL="sqlite://"))
+
+    fake_notion = SimpleNamespace(
+        get_profile_stats_by_name=AsyncMock(return_value=SAMPLE_PROFILE),
+        update_profile_stats_connects=AsyncMock(),
+        close=AsyncMock(),
+    )
+    monkeypatch.setattr(connects_this_week, "NotionConnector", lambda: fake_notion)
+    monkeypatch.setattr(connects_this_week, "SurveyStepsDB", FakeDB)
+
+    result = await connects_this_week.handle(COMMAND_PAYLOAD)
+
+    with open(log_file, "a") as f:
+        f.write("Step: handle called\n")
+        f.write(f"Output: {result}\n")
+
+    assert result == connects_this_week.ERROR_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_end_to_end(monkeypatch, tmp_path):
+    """Simulate slash command call end-to-end through handler."""
+    log_file = tmp_path / "e2e_log.txt"
+    log_file.write_text(f"Input: {COMMAND_PAYLOAD}\n")
+
+    session = DummySession()
+    monkeypatch.setattr(connects_this_week.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setattr(connects_this_week, "Config", SimpleNamespace(DATABASE_URL="sqlite://"))
+
+    fake_notion = SimpleNamespace(
+        get_profile_stats_by_name=AsyncMock(return_value=SAMPLE_PROFILE),
+        update_profile_stats_connects=AsyncMock(),
+        close=AsyncMock(),
+    )
+    monkeypatch.setattr(connects_this_week, "NotionConnector", lambda: fake_notion)
+    monkeypatch.setattr(connects_this_week, "SurveyStepsDB", FakeDB)
+
+    result = await connects_this_week.handle(COMMAND_PAYLOAD.copy())
+
+    with open(log_file, "a") as f:
+        f.write("Step: handle called\n")
+        f.write(f"Output: {result}\n")
+
+    expected = (
+        "Записав! Upwork connects: залишилось "
+        f"{COMMAND_PAYLOAD['result']['connects']} на цьому тиждні."
+    )
+    assert result == expected


### PR DESCRIPTION
## Summary
- handle `/connects_this_week` to store Upwork connects, update Notion, and record survey progress
- test connects handler under success, no profile, failure, and end-to-end cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04598ae5c833184a831b61eb0bbd5