### PR TITLE
feat: add day off handler

### DIFF
--- a/services/cmd/day_off.py
+++ b/services/cmd/day_off.py
@@ -1,6 +1,56 @@
+from __future__ import annotations
+
 from typing import Any, Dict
+
+from config import Config
+from services.calendar_connector import CalendarConnector
+try:  # pragma: no cover - optional dependency
+    from services.survey_steps_db import SurveyStepsDB
+except Exception:  # pragma: no cover - databases package missing
+    SurveyStepsDB = None
+from services.date_utils import format_date_ua
+
+calendar = CalendarConnector()
+db_url = getattr(Config, "DATABASE_URL", "")
+_steps_db = SurveyStepsDB(db_url) if SurveyStepsDB and db_url else None
+
+
+async def _mark_step(channel_id: str, step: str) -> None:
+    if _steps_db:
+        await _steps_db.upsert_step(channel_id, step, True)
 
 
 async def handle(payload: Dict[str, Any]) -> str:
-    """Placeholder handler for the day_off command."""
-    return "Команда day_off ще не реалізована."
+    """Record day-off dates for the current or next week."""
+
+    try:
+        value = (
+            payload.get("result", {}).get("value")
+            or payload.get("result", {}).get("daysSelected")
+        )
+        step = payload.get("command")
+        if step == "survey":
+            step = payload.get("result", {}).get("stepName")
+        if value == "Nothing" or not value:
+            await _mark_step(payload.get("channelId", ""), step)
+            return "Записав! Вихідних нема"
+        if isinstance(value, str):
+            value = [value]
+        author = payload.get("author", "")
+        for day in value:
+            resp = await calendar.create_day_off_event(author, day)
+            if resp.get("status") != "ok":
+                raise RuntimeError(resp.get("message"))
+        await _mark_step(payload.get("channelId", ""), step)
+        if len(value) == 1:
+            return (
+                f"Вихідний: {format_date_ua(value[0])} записано.\n"
+                "Не забудь попередити клієнтів."
+            )
+        formatted = ", ".join(format_date_ua(v) for v in value)
+        return (
+            f"Вихідні: {formatted} записані.\n"
+            "Не забудь попередити клієнтів."
+        )
+    except Exception:
+        return "Спробуй трохи піздніше. Я тут пораюсь по хаті."

--- a/services/date_utils.py
+++ b/services/date_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+_MONTHS = [
+    "січня",
+    "лютого",
+    "березня",
+    "квітня",
+    "травня",
+    "червня",
+    "липня",
+    "серпня",
+    "вересня",
+    "жовтня",
+    "листопада",
+    "грудня",
+]
+
+
+def format_date_ua(date_str: str) -> str:
+    """Return a date formatted as ``DD MMMM YY`` in Ukrainian."""
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return f"{dt.day:02d} {_MONTHS[dt.month - 1]} {dt.year % 100:02d}"

--- a/services/router.py
+++ b/services/router.py
@@ -34,6 +34,8 @@ HANDLERS: Dict[str, Callable[[Dict[str, Any]], Awaitable[str]]] = {
     "workload_nextweek": workload_nextweek.handle,
     "connects_this_week": connects_this_week.handle,
     "day_off": day_off.handle,
+    "day_off_thisweek": day_off.handle,
+    "day_off_nextweek": day_off.handle,
     "vacation": vacation.handle,
     "check_channel": check_channel.handle,
 }

--- a/tests/test_day_off_e2e.py
+++ b/tests/test_day_off_e2e.py
@@ -1,0 +1,163 @@
+import sys
+import json
+import re
+from pathlib import Path
+import types
+import logging
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "services"))
+
+
+fake_google = types.ModuleType("google")
+auth = types.ModuleType("auth")
+transport = types.ModuleType("transport")
+requests_mod = types.ModuleType("requests")
+requests_mod.Request = object
+transport.requests = requests_mod
+auth.transport = transport
+oauth2 = types.ModuleType("oauth2")
+service_account = types.ModuleType("service_account")
+service_account.Credentials = object
+oauth2.service_account = service_account
+fake_google.auth = auth
+fake_google.oauth2 = oauth2
+sys.modules["google"] = fake_google
+sys.modules["google.auth"] = auth
+sys.modules["google.auth.transport"] = transport
+sys.modules["google.auth.transport.requests"] = requests_mod
+sys.modules["google.oauth2"] = oauth2
+sys.modules["google.oauth2.service_account"] = service_account
+
+
+class DummyConfig:
+    DATABASE_URL = ""
+    NOTION_TEAM_DIRECTORY_DB_ID = ""
+    NOTION_TOKEN = ""
+    NOTION_WORKLOAD_DB_ID = ""
+    NOTION_PROFILE_STATS_DB_ID = ""
+    N8N_WEBHOOK_URL = ""
+    WEBHOOK_AUTH_TOKEN = ""
+    SESSION_TTL = 1
+
+
+config_mod = types.SimpleNamespace(
+    Config=DummyConfig, logger=logging.getLogger("test"), Strings=object()
+)
+sys.modules["config"] = config_mod
+
+import router
+import services.cmd.day_off as day_off
+from services.date_utils import format_date_ua
+
+
+def load_payload_example(title: str) -> dict:
+    text = Path(ROOT / "payload_examples.txt").read_text()
+    start = text.index(title)
+    snippet = text[start:]
+    first = snippet.index("{")
+    depth = 0
+    end = first
+    for i, ch in enumerate(snippet[first:]):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = first + i + 1
+                break
+    return json.loads(snippet[first:end])
+
+
+def load_notion_lookup():
+    text = Path(ROOT / "responses").read_text()
+    name = re.search(r'plain_text": "([^\"]+Lernichenko)', text).group(1)
+    todo_url = re.search(r'https://www.notion.so/[0-9a-f-]+', text).group(0)
+    return {"results": [{"name": name, "discord_id": "321", "channel_id": "123", "to_do": todo_url}]}
+
+
+class DummyCalendar:
+    def __init__(self):
+        self.calls = []
+
+    async def create_day_off_event(self, name: str, date: str):
+        self.calls.append((name, date))
+        return {"status": "ok", "event_id": "1"}
+
+
+class DummySteps:
+    def __init__(self):
+        self.calls = []
+
+    async def upsert_step(self, session_id: str, step: str, completed: bool):
+        self.calls.append((session_id, step, completed))
+        return {"status": "ok"}
+
+
+def _prepare(monkeypatch):
+    async def lookup(channel_id):
+        return load_notion_lookup()
+
+    monkeypatch.setattr(router._notio, "find_team_directory_by_channel", lookup)
+    cal = DummyCalendar()
+    steps = DummySteps()
+    monkeypatch.setattr(day_off, "calendar", cal)
+    monkeypatch.setattr(day_off, "_steps_db", steps)
+    return cal, steps
+
+
+@pytest.mark.asyncio
+async def test_day_off_thisweek_e2e(tmp_path, monkeypatch):
+    log = tmp_path / "day_off_thisweek_log.txt"
+    log.write_text("Input: day_off_thisweek\n")
+
+    cal, steps = _prepare(monkeypatch)
+
+    payload = load_payload_example("Day Off Slash Command Payload (e.g., /day_off_nextweek)")
+    payload.update({"command": "day_off_thisweek", "result": {"value": ["2024-02-05"]}})
+    payload["channelId"] = "123"
+    payload["sessionId"] = "123_321"
+    payload["userId"] = "321"
+
+    with open(log, "a") as f:
+        f.write("Step: dispatch\n")
+    result = await router.dispatch(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {result}\n")
+
+    name = load_notion_lookup()["results"][0]["name"]
+    assert cal.calls == [(name, "2024-02-05")]
+    assert steps.calls == [("123", "day_off_thisweek", True)]
+    expected = f"Вихідний: {format_date_ua('2024-02-05')} записано.\nНе забудь попередити клієнтів."
+    assert result == {"output": expected}
+
+
+@pytest.mark.asyncio
+async def test_day_off_nextweek_e2e(tmp_path, monkeypatch):
+    log = tmp_path / "day_off_nextweek_log.txt"
+    log.write_text("Input: day_off_nextweek\n")
+
+    cal, steps = _prepare(monkeypatch)
+
+    payload = load_payload_example("Day Off Slash Command Payload (e.g., /day_off_nextweek)")
+    payload.update({"command": "day_off_nextweek", "result": {"value": ["2024-02-05", "2024-02-06"]}})
+    payload["channelId"] = "123"
+    payload["sessionId"] = "123_321"
+    payload["userId"] = "321"
+
+    with open(log, "a") as f:
+        f.write("Step: dispatch\n")
+    result = await router.dispatch(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {result}\n")
+
+    name = load_notion_lookup()["results"][0]["name"]
+    assert cal.calls == [(name, "2024-02-05"), (name, "2024-02-06")]
+    assert steps.calls == [("123", "day_off_nextweek", True)]
+    formatted = ", ".join([format_date_ua("2024-02-05"), format_date_ua("2024-02-06")])
+    expected = f"Вихідні: {formatted} записані.\nНе забудь попередити клієнтів."
+    assert result == {"output": expected}
+

--- a/tests/test_day_off_handler.py
+++ b/tests/test_day_off_handler.py
@@ -1,0 +1,212 @@
+import sys
+import json
+import re
+from pathlib import Path
+import types
+import logging
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "services"))
+
+
+fake_google = types.ModuleType("google")
+auth = types.ModuleType("auth")
+transport = types.ModuleType("transport")
+requests_mod = types.ModuleType("requests")
+requests_mod.Request = object
+transport.requests = requests_mod
+auth.transport = transport
+oauth2 = types.ModuleType("oauth2")
+service_account = types.ModuleType("service_account")
+service_account.Credentials = object
+oauth2.service_account = service_account
+fake_google.auth = auth
+fake_google.oauth2 = oauth2
+sys.modules["google"] = fake_google
+sys.modules["google.auth"] = auth
+sys.modules["google.auth.transport"] = transport
+sys.modules["google.auth.transport.requests"] = requests_mod
+sys.modules["google.oauth2"] = oauth2
+sys.modules["google.oauth2.service_account"] = service_account
+
+
+class DummyConfig:
+    DATABASE_URL = ""
+    NOTION_TEAM_DIRECTORY_DB_ID = ""
+    NOTION_TOKEN = ""
+    NOTION_WORKLOAD_DB_ID = ""
+    NOTION_PROFILE_STATS_DB_ID = ""
+    N8N_WEBHOOK_URL = ""
+    WEBHOOK_AUTH_TOKEN = ""
+    SESSION_TTL = 1
+
+
+config_mod = types.SimpleNamespace(
+    Config=DummyConfig, logger=logging.getLogger("test"), Strings=object()
+)
+sys.modules["config"] = config_mod
+
+import services.cmd.day_off as day_off
+from services.date_utils import format_date_ua
+
+
+def load_payload_example(title: str) -> dict:
+    text = Path(ROOT / "payload_examples.txt").read_text()
+    start = text.index(title)
+    snippet = text[start:]
+    first = snippet.index("{")
+    depth = 0
+    end = first
+    for i, ch in enumerate(snippet[first:]):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = first + i + 1
+                break
+    return json.loads(snippet[first:end])
+
+
+def load_author() -> str:
+    text = Path(ROOT / "responses").read_text()
+    return re.search(r'plain_text": "([^\"]+Lernichenko)', text).group(1)
+
+
+class DummyCalendar:
+    def __init__(self, fail: bool = False):
+        self.calls = []
+        self.fail = fail
+
+    async def create_day_off_event(self, name: str, date: str):
+        self.calls.append((name, date))
+        if self.fail:
+            return {"status": "error", "message": "boom"}
+        return {"status": "ok", "event_id": "1"}
+
+
+class DummySteps:
+    def __init__(self):
+        self.calls = []
+
+    async def upsert_step(self, session_id: str, step: str, completed: bool):
+        self.calls.append((session_id, step, completed))
+        return {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_no_dates(tmp_path, monkeypatch):
+    log = tmp_path / "no_dates_log.txt"
+    log.write_text("Input: Nothing\n")
+
+    cal = DummyCalendar()
+    steps = DummySteps()
+    monkeypatch.setattr(day_off, "calendar", cal)
+    monkeypatch.setattr(day_off, "_steps_db", steps)
+
+    payload = load_payload_example("Day Off Slash Command Payload (e.g., /day_off_nextweek)")
+    payload["command"] = "day_off_thisweek"
+    payload["result"]["value"] = "Nothing"
+    payload["author"] = load_author()
+    payload["channelId"] = "123"
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    out = await day_off.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {out}\n")
+
+    assert not cal.calls
+    assert steps.calls == [("123", "day_off_thisweek", True)]
+    assert out == "Записав! Вихідних нема"
+
+
+@pytest.mark.asyncio
+async def test_one_date(tmp_path, monkeypatch):
+    log = tmp_path / "one_date_log.txt"
+    log.write_text("Input: one date\n")
+
+    cal = DummyCalendar()
+    steps = DummySteps()
+    monkeypatch.setattr(day_off, "calendar", cal)
+    monkeypatch.setattr(day_off, "_steps_db", steps)
+
+    payload = load_payload_example("Day Off Slash Command Payload (e.g., /day_off_nextweek)")
+    payload["command"] = "day_off_thisweek"
+    payload["result"]["value"] = ["2024-02-05"]
+    payload["author"] = load_author()
+    payload["channelId"] = "123"
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    out = await day_off.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {out}\n")
+
+    assert cal.calls == [(load_author(), "2024-02-05")]
+    assert steps.calls == [("123", "day_off_thisweek", True)]
+    expected = f"Вихідний: {format_date_ua('2024-02-05')} записано.\nНе забудь попередити клієнтів."
+    assert out == expected
+
+
+@pytest.mark.asyncio
+async def test_many_dates(tmp_path, monkeypatch):
+    log = tmp_path / "many_dates_log.txt"
+    log.write_text("Input: many dates\n")
+
+    cal = DummyCalendar()
+    steps = DummySteps()
+    monkeypatch.setattr(day_off, "calendar", cal)
+    monkeypatch.setattr(day_off, "_steps_db", steps)
+
+    payload = load_payload_example("Day Off Slash Command Payload (e.g., /day_off_nextweek)")
+    payload["command"] = "day_off_nextweek"
+    payload["result"]["value"] = ["2024-02-05", "2024-02-06"]
+    payload["author"] = load_author()
+    payload["channelId"] = "123"
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    out = await day_off.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {out}\n")
+
+    assert cal.calls == [
+        (load_author(), "2024-02-05"),
+        (load_author(), "2024-02-06"),
+    ]
+    assert steps.calls == [("123", "day_off_nextweek", True)]
+    formatted = ", ".join([format_date_ua("2024-02-05"), format_date_ua("2024-02-06")])
+    expected = f"Вихідні: {formatted} записані.\nНе забудь попередити клієнтів."
+    assert out == expected
+
+
+@pytest.mark.asyncio
+async def test_calendar_error(tmp_path, monkeypatch):
+    log = tmp_path / "calendar_error_log.txt"
+    log.write_text("Input: calendar error\n")
+
+    cal = DummyCalendar(fail=True)
+    steps = DummySteps()
+    monkeypatch.setattr(day_off, "calendar", cal)
+    monkeypatch.setattr(day_off, "_steps_db", steps)
+
+    payload = load_payload_example("Day Off Slash Command Payload (e.g., /day_off_nextweek)")
+    payload["command"] = "day_off_nextweek"
+    payload["result"]["value"] = ["2024-02-05"]
+    payload["author"] = load_author()
+    payload["channelId"] = "123"
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    out = await day_off.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {out}\n")
+
+    assert cal.calls == [(load_author(), "2024-02-05")]
+    assert steps.calls == []
+    assert out == "Спробуй трохи піздніше. Я тут пораюсь по хаті."
+

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -45,6 +45,7 @@ def load_notion_lookup():
     return {"results": [{"name": name, "discord_id": "321", "channel_id": "123", "to_do": todo_url}]}
 # Stub config to avoid heavy imports
 class DummyConfig:
+    DATABASE_URL = ""
     NOTION_TEAM_DIRECTORY_DB_ID = ""
     NOTION_TOKEN = ""
     NOTION_WORKLOAD_DB_ID = ""

--- a/tests/test_survey_e2e.py
+++ b/tests/test_survey_e2e.py
@@ -12,6 +12,7 @@ sys.path.append(str(ROOT / "services"))
 
 
 class DummyConfig:
+    DATABASE_URL = ""
     NOTION_TEAM_DIRECTORY_DB_ID = ""
     NOTION_TOKEN = ""
     NOTION_WORKLOAD_DB_ID = ""


### PR DESCRIPTION
## Summary
- implement day off command handler with calendar integration
- add Ukrainian date formatter
- cover day off flows with unit and e2e tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0459ed4f0833194df444fd889ed2e