### PR TITLE
Implement check_channel handler

### DIFF
--- a/n8nTasks/Task13_CheckChannelHandler.md
+++ b/n8nTasks/Task13_CheckChannelHandler.md
@@ -1,19 +1,18 @@
 # Task 13: Check Channel Handler
 
 ## Goal
-Implement `handle_check_channel` to verify that the current channel is registered and ready for surveys. This handler is invoked internally (`author` is `"system"`) to ensure a channel has a Team Directory entry before user interactions begin.
+Implement `handle_check_channel` to report pending survey steps for the current channel. This command is triggered internally (`author` is `"system"`) before user interaction begins.
 
 ## Business Logic
-- Triggered as a system check, it uses `channelId` to search for an existing channel record in Notion.
-- Each entry exposes `Name`, `Discord ID`, `Discord channel ID`, and `ToDo` properties.
-- If a record exists, return its assigned user name.
-- If missing, create the channel entry with default survey configuration and acknowledge the registration.
-- Any Notion failure returns the generic error message.
+- Use `channelId` to query the `n8n_survey_steps_missed` table for this week.
+- Collect step names where `completed=false`.
+- Return the list of unique pending steps. If none are found, the list is empty.
+- Any database failure returns the generic error message.
 
 ### Input Variants
-- **Existing channel** – record found in Notion.
-- **Missing channel** – no record; create a new one.
-- **Generic failure** – any Notion error triggers the fallback message.
+- **No pending steps** – all required steps are completed for the week.
+- **Pending steps** – some steps exist with `completed=false`.
+- **Database failure** – query raises an exception.
 
 #### Example Payload
 ```json
@@ -32,59 +31,32 @@ Implement `handle_check_channel` to verify that the current channel is registere
 ```
 
 ### Output Variants
-- Success: `{ "output": "Канал успішно зареєстровано на {property_name}" }`
+- Success: `{ "output": true, "steps": [] }`
 - Error: `{ "output": "Спробуй трохи піздніше. Я тут пораюсь по хаті." }`
 
 ## Steps
-1. **Read from Notion** – `POST /v1/databases/{TD_DB}/query` filtering by
-   `"Discord channel ID" == payload.channelId`.
-   Example response (from `responses` when channel exists):
-   ```json
-   {
-     "results": [
-       {
-         "id": "abc",
-         "url": "https://www.notion.so/Roman-Lernichenko-b02bf04c43e4404ca4e21707ae8b61cc",
-         "properties": {
-           "Name": {"title": [{"plain_text": "Roman Lernichenko"}]},
-           "Discord ID": {"rich_text": []},
-           "Discord channel ID": {"rich_text": []}
-         }
-       }
-     ]
-   }
-   ```
-2. If no page is found, **write to Notion** – `POST /v1/pages` with default
-   properties:
-   ```json
-   {
-     "parent": {"database_id": "{TD_DB}"},
-     "properties": {
-       "Name": {"title": [{"text": {"content": payload.channelName}}]},
-       "Discord channel ID": {"rich_text": [{"text": {"content": payload.channelId}}]}
-     }
-   }
-   ```
-   Example success response: `{ "url": "https://www.notion.so/new-channel" }`.
-3. Return a confirmation with the channel's assigned name or an error.
+1. Compute start of the current week (Monday 00:00 UTC).
+2. **Read from Postgres** – `SELECT step_name, completed, updated FROM n8n_survey_steps_missed` filtering by `session_id` and `updated >= week_start`.
+3. Collect step names with `completed=false` and remove duplicates.
+4. Return `{ "output": true, "steps": pending_steps }` or the error message if the query fails.
 
 ## Pseudocode
 ```python
 async def handle_check_channel(payload):
     try:
-        page = await notion.find_channel(payload["channelId"])
-        if not page:
-            page = await notion.create_channel(payload["channelId"], payload["channelName"])
-        name = page.get("name", payload["channelName"])
-        return {"output": f"Канал успішно зареєстровано на {name}"}
+        repo = SurveyStepsDB(DATABASE_URL)
+        start = start_of_week()
+        records = await repo.fetch_week(payload["channelId"], start)
+        steps = [r["step_name"] for r in records if not r["completed"]]
+        return {"output": True, "steps": list(dict.fromkeys(steps))}
     except Exception:
         return {"output": "Спробуй трохи піздніше. Я тут пораюсь по хаті."}
 ```
 
 ## Tests
 - Unit:
-  - **Existing channel** – mock `find_channel` to return `{ "name": "User" }` and ensure `create_channel` is not called.
-  - **Missing channel** – mock `find_channel` to return `None` and verify `create_channel` is invoked.
-  - **Notion error** – mock `find_channel` to raise and assert error message.
-- End-to-end: trigger the system check and confirm no user-visible errors occur.
+  - **No pending steps** – DB returns only `completed=true` rows.
+  - **Pending steps** – DB returns at least one `completed=false` row.
+  - **Database failure** – simulate exception and assert error message.
+- End-to-end: dispatch `check_channel` and ensure the response contains the pending `steps` list.
 - All tests must log inputs, steps, and outputs to a file for later review.

--- a/services/cmd/check_channel.py
+++ b/services/cmd/check_channel.py
@@ -1,6 +1,24 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from config import Config
+from services.survey_steps_db import SurveyStepsDB
 
 
-async def handle(payload: Dict[str, Any]) -> str:
-    """Placeholder handler for the check_channel command."""
-    return "Команда check_channel ще не реалізована."
+async def handle(payload: Dict[str, Any], repo: Optional[SurveyStepsDB] = None) -> Dict[str, Any] | str:
+    """Return pending survey steps for the channel or an error message."""
+    try:
+        db = repo or SurveyStepsDB(Config.DATABASE_URL)
+        now = datetime.utcnow()
+        start = (now - timedelta(days=now.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        records = await db.fetch_week(payload["channelId"], start)
+        steps = [r["step_name"] for r in records if not r["completed"]]
+        if repo is None:
+            await db.close()
+        return {"output": True, "steps": list(dict.fromkeys(steps))}
+    except Exception:
+        return "Спробуй трохи піздніше. Я тут пораюсь по хаті."

--- a/tests/test_check_channel.py
+++ b/tests/test_check_channel.py
@@ -1,0 +1,112 @@
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from databases import Database
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "services"))
+
+text = Path(ROOT / "payload_examples.txt").read_text()
+SURVEY_FLOW = re.findall(r"\"stepName\": \"([^\"]+)\"", text)
+
+from services.survey_steps_db import SurveyStepsDB
+from services.cmd.check_channel import handle
+
+
+def load_payload_example(title: str) -> dict:
+    text = Path(ROOT / "payload_examples.txt").read_text()
+    start = text.index(title)
+    segment = text[start:]
+    match = re.search(r"```json\n(.*?)(?:\n```|\n## )", segment, re.DOTALL)
+    return json.loads(match.group(1))
+
+
+def load_sample_name() -> str:
+    text = Path(ROOT / "responses").read_text()
+    return re.search(r'plain_text": "([^"]+)"', text).group(1)
+
+
+CREATE_TABLE = (
+    "CREATE TABLE IF NOT EXISTS n8n_survey_steps_missed ("
+    "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "session_id TEXT NOT NULL,"
+    "step_name TEXT NOT NULL,"
+    "completed BOOLEAN NOT NULL,"
+    "updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+    "UNIQUE(session_id, step_name)"
+    ")"
+)
+
+
+@pytest.mark.asyncio
+async def test_handle_no_pending_steps(tmp_path):
+    log = tmp_path / "no_pending_log.txt"
+    payload = load_payload_example("check_channel Command Payload")
+    payload.update({"channelId": "CHAN", "userId": "USER", "sessionId": "CHAN_USER"})
+    payload["channelName"] = load_sample_name()
+    log.write_text(f"Input: {payload}\n")
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    database = Database(db_url)
+    await database.connect()
+    await database.execute(CREATE_TABLE)
+    repo = SurveyStepsDB(db_url, db=database)
+    await repo.upsert_step("CHAN", SURVEY_FLOW[0], True)
+
+    result = await handle(payload, repo)
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+        f.write(f"Output: {result}\n")
+
+    assert result == {"output": True, "steps": []}
+    await database.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_handle_pending_steps(tmp_path):
+    log = tmp_path / "pending_log.txt"
+    payload = load_payload_example("check_channel Command Payload")
+    payload.update({"channelId": "CHAN", "userId": "USER", "sessionId": "CHAN_USER"})
+    payload["channelName"] = load_sample_name()
+    log.write_text(f"Input: {payload}\n")
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    database = Database(db_url)
+    await database.connect()
+    await database.execute(CREATE_TABLE)
+    repo = SurveyStepsDB(db_url, db=database)
+    await repo.upsert_step("CHAN", SURVEY_FLOW[0], False)
+
+    result = await handle(payload, repo)
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+        f.write(f"Output: {result}\n")
+
+    assert result == {"output": True, "steps": [SURVEY_FLOW[0]]}
+    await database.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_handle_db_failure(tmp_path, monkeypatch):
+    log = tmp_path / "db_failure_log.txt"
+    payload = load_payload_example("check_channel Command Payload")
+    payload.update({"channelId": "CHAN", "userId": "USER", "sessionId": "CHAN_USER"})
+    payload["channelName"] = load_sample_name()
+    log.write_text(f"Input: {payload}\n")
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(SurveyStepsDB, "fetch_week", boom)
+    repo = SurveyStepsDB("sqlite:///:memory:")
+
+    result = await handle(payload, repo)
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+        f.write(f"Output: {result}\n")
+
+    assert result == "Спробуй трохи піздніше. Я тут пораюсь по хаті."


### PR DESCRIPTION
## Summary
- Correct Task13 to describe database-backed channel checks
- Implement check_channel handler to gather pending survey steps from Postgres
- Add unit tests for no pending, pending, and database failure scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c049e53c8c8331a1fa21fe21b47926