### PR TITLE
Require Postgres SurveyStepsDB backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cachetools==5.3.3
 pytz==2024.1
 notion-client
 pytest-asyncio
-databases[sqlite]
+databases[sqlite,postgresql]
+asyncpg
 google-auth
 requests

--- a/services/cmd/connects_this_week.py
+++ b/services/cmd/connects_this_week.py
@@ -9,11 +9,7 @@ import aiohttp
 from config import Config
 from services.notion_connector import NotionConnector
 from services.logging_utils import get_logger
-
-try:  # pragma: no cover - optional dependency
-    from services.survey_steps_db import SurveyStepsDB
-except Exception:  # pragma: no cover - missing databases package
-    SurveyStepsDB = None  # type: ignore
+from services.survey_steps_db import SurveyStepsDB
 
 
 ERROR_MESSAGE = "Спробуй трохи піздніше. Я тут пораюсь по хаті."
@@ -27,13 +23,12 @@ async def handle(payload: Dict[str, Any]) -> str:
         log.debug("parsed connects", extra={"connects": connects})
 
         # mark survey step as completed using channel id as session id
-        if SurveyStepsDB and Config.DATABASE_URL:
-            db = SurveyStepsDB(Config.DATABASE_URL)
-            try:
-                await db.upsert_step(payload["channelId"], "connects_thisweek", True)
-                log.info("step recorded")
-            finally:
-                await db.close()
+        db = SurveyStepsDB(Config.DATABASE_URL)
+        try:
+            await db.upsert_step(payload["channelId"], "connects_thisweek", True)
+            log.info("step recorded")
+        finally:
+            await db.close()
 
         # post connects count to external database
         url = Config.CONNECTS_URL

--- a/services/cmd/workload_nextweek.py
+++ b/services/cmd/workload_nextweek.py
@@ -2,20 +2,22 @@ from typing import Any, Dict, Optional, Union
 from services.notion_connector import NotionConnector
 from config import Config
 from services.logging_utils import get_logger
-
-try:
-    from services.survey_steps_db import SurveyStepsDB
-except Exception:  # pragma: no cover - missing optional dep
-    SurveyStepsDB = None
+from services.survey_steps_db import SurveyStepsDB
 
 ERROR_MSG = "Спробуй трохи піздніше. Я тут пораюсь по хаті."
 
 _notion = NotionConnector()
-_steps: Optional[SurveyStepsDB]
-try:
-    _steps = SurveyStepsDB(Config.DATABASE_URL)
-except Exception:  # pragma: no cover - optional database
-    _steps = None
+_steps: Optional[SurveyStepsDB] = None
+
+
+def _ensure_db() -> SurveyStepsDB:
+    global _steps
+    if _steps is None:
+        db_url = getattr(Config, "DATABASE_URL", "")
+        if not db_url:
+            raise RuntimeError("DATABASE_URL not configured")
+        _steps = SurveyStepsDB(db_url)
+    return _steps
 
 
 def template(hours: Union[int, float]) -> str:
@@ -36,9 +38,9 @@ async def handle(payload: Dict[str, Any]) -> str:
         page = results[0]
         await _notion.update_workload_day(page["id"], "Next week plan", hours)
         log.info("workload updated", extra={"page_id": page["id"]})
-        if _steps:
-            await _steps.upsert_step(payload["channelId"], "workload_nextweek", True)
-            log.info("step recorded")
+        db = _ensure_db()
+        await db.upsert_step(payload["channelId"], "workload_nextweek", True)
+        log.info("step recorded")
         return template(hours)
     except Exception:
         log.exception("workload_nextweek failed")

--- a/tests/e2e/test_survey_scenarios.py
+++ b/tests/e2e/test_survey_scenarios.py
@@ -14,7 +14,7 @@ sys.path.append(str(ROOT / "services"))
 @pytest.fixture
 def setup_env(monkeypatch):
     class DummyConfig:
-        DATABASE_URL = ""
+        DATABASE_URL = "sqlite://"
         NOTION_TEAM_DIRECTORY_DB_ID = ""
         NOTION_TOKEN = ""
         NOTION_WORKLOAD_DB_ID = ""

--- a/tests/test_day_off_handler.py
+++ b/tests/test_day_off_handler.py
@@ -34,7 +34,7 @@ sys.modules["google.oauth2.service_account"] = service_account
 
 
 class DummyConfig:
-    DATABASE_URL = ""
+    DATABASE_URL = "sqlite://"
     NOTION_TEAM_DIRECTORY_DB_ID = ""
     NOTION_TOKEN = ""
     NOTION_WORKLOAD_DB_ID = ""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -64,7 +64,7 @@ def load_notion_lookup():
 base_logger = logging.getLogger("discord_bot")
 
 class DummyConfig:
-    DATABASE_URL = ""
+    DATABASE_URL = "sqlite://"
     NOTION_TEAM_DIRECTORY_DB_ID = ""
     NOTION_TOKEN = ""
     NOTION_WORKLOAD_DB_ID = ""

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -56,7 +56,7 @@ def load_notion_lookup():
     }
 # Stub config to avoid heavy imports
 class DummyConfig:
-    DATABASE_URL = ""
+    DATABASE_URL = "sqlite://"
     NOTION_TEAM_DIRECTORY_DB_ID = ""
     NOTION_TOKEN = ""
     NOTION_WORKLOAD_DB_ID = ""

--- a/tests/test_survey_e2e.py
+++ b/tests/test_survey_e2e.py
@@ -12,7 +12,7 @@ sys.path.append(str(ROOT / "services"))
 
 
 class DummyConfig:
-    DATABASE_URL = ""
+    DATABASE_URL = "sqlite://"
     NOTION_TEAM_DIRECTORY_DB_ID = ""
     NOTION_TOKEN = ""
     NOTION_WORKLOAD_DB_ID = ""

--- a/tests/test_vacation.py
+++ b/tests/test_vacation.py
@@ -86,6 +86,10 @@ async def test_handle_vacation_success(tmp_path, monkeypatch):
     payload["result"]["start_date"] = start_date
     payload["result"]["end_date"] = end_date
 
+    fake_db = FakeDB()
+    monkeypatch.setattr(vacation, "SurveyStepsDB", lambda *_: fake_db)
+    monkeypatch.setattr(vacation, "Config", types.SimpleNamespace(DATABASE_URL="sqlite://"))
+
     async def fake_create(name, start, end, tz):
         assert name == payload["author"]
         assert start == start_date and end == end_date and tz == "Europe/Kyiv"
@@ -120,6 +124,10 @@ async def test_handle_vacation_calendar_error(tmp_path, monkeypatch):
     payload["result"]["start_date"] = start_date
     payload["result"]["end_date"] = end_date
 
+    fake_db = FakeDB()
+    monkeypatch.setattr(vacation, "SurveyStepsDB", lambda *_: fake_db)
+    monkeypatch.setattr(vacation, "Config", types.SimpleNamespace(DATABASE_URL="sqlite://"))
+
     async def fake_create(name, start, end, tz):
         raise RuntimeError("calendar down")
 
@@ -153,6 +161,9 @@ async def test_vacation_e2e(tmp_path, monkeypatch):
     async def fake_create(name, start, end, tz):
         return {"status": "ok", "event_id": event_id}
 
+    fake_db = FakeDB()
+    monkeypatch.setattr(vacation, "SurveyStepsDB", lambda *_: fake_db)
+    monkeypatch.setattr(vacation, "Config", types.SimpleNamespace(DATABASE_URL="sqlite://"))
     monkeypatch.setattr(router._notio, "find_team_directory_by_channel", fake_lookup)
     monkeypatch.setattr(
         vacation, "calendar", types.SimpleNamespace(create_vacation_event=fake_create)

--- a/tests/test_workload_today.py
+++ b/tests/test_workload_today.py
@@ -143,7 +143,16 @@ async def test_handle_workload_today_error(tmp_path, monkeypatch):
 
     monkeypatch.setattr(workload_today._notio, "query_database", fake_query)
     monkeypatch.setattr(workload_today._notio, "update_workload_day", fake_update)
-    monkeypatch.setattr(workload_today, "_steps_db", None)
+    monkeypatch.setattr(
+        workload_today,
+        "_steps_db",
+        types.SimpleNamespace(upsert_step=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(
+        workload_today,
+        "Config",
+        types.SimpleNamespace(DATABASE_URL="sqlite://", NOTION_WORKLOAD_DB_ID="db"),
+    )
 
     result = await workload_today.handle(payload)
 
@@ -165,8 +174,19 @@ async def test_handle_workload_today_user_not_found(tmp_path, monkeypatch):
         return {"status": "ok", "results": []}
 
     monkeypatch.setattr(workload_today._notio, "query_database", fake_query)
-    monkeypatch.setattr(workload_today._notio, "update_workload_day", lambda *a, **k: None)
-    monkeypatch.setattr(workload_today, "_steps_db", None)
+    monkeypatch.setattr(
+        workload_today._notio, "update_workload_day", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        workload_today,
+        "_steps_db",
+        types.SimpleNamespace(upsert_step=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(
+        workload_today,
+        "Config",
+        types.SimpleNamespace(DATABASE_URL="sqlite://", NOTION_WORKLOAD_DB_ID="db"),
+    )
 
     result = await workload_today.handle(payload)
 


### PR DESCRIPTION
## Summary
- Enforce SurveyStepsDB usage across command handlers and drop optional fallbacks
- Add Postgres driver to dependencies to ensure asyncpg backend is available
- Adjust tests to supply a database URL and mock SurveyStepsDB interactions
- Explicitly depend on asyncpg so missing backend errors are avoided

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19405a40c8331985a42f65e4762fe