### PR TITLE
Handle survey with non-required steps by finishing flow

### DIFF
--- a/discord_bot/commands/survey.py
+++ b/discord_bot/commands/survey.py
@@ -132,6 +132,18 @@ async def finish_empty_survey(
         return
     try:
         minimal = survey_manager.create_survey(user_id, channel_id, [], session_id)
+        # Second check_channel call to populate survey.todo_url before finishing
+        payload = {
+            "command": "check_channel",
+            "channelId": channel_id,
+            "sessionId": session_id,
+        }
+        try:
+            await webhook_service.send_webhook_with_retry(None, payload, {})
+        except Exception as e:
+            logger.warning(
+                f"check_channel failed to refresh todo_url for channel {channel_id}: {e}"
+            )
         minimal.current_index = len(minimal.steps)
         await finish_survey(bot, channel, minimal)
     except ValueError as e:

--- a/responses
+++ b/responses
@@ -3120,3 +3120,8 @@ todo page
       "content": "@Dmytro Bronfain please update All work profile - Dmytro Bronfain "
     }
   ]
+
+====
+check_channel nonmatching steps response
+
+{"output": {"output": true, "steps": ["day_off_thisweek", "vacation"]}}

--- a/tests/test_survey_start.py
+++ b/tests/test_survey_start.py
@@ -3,9 +3,8 @@ import re
 import sys
 import types
 import importlib.util
+import asyncio
 from pathlib import Path
-
-import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
@@ -25,6 +24,13 @@ def load_check_channel_response() -> dict:
     return json.loads(match.group(0))
 
 
+def load_check_channel_nonmatching_response() -> dict:
+    text = (ROOT / "responses").read_text()
+    start = text.index("check_channel nonmatching steps response")
+    match = re.search(r"{\s*\"output\"[\s\S]*?}\s*}", text[start:])
+    return json.loads(match.group(0))
+
+
 class DummyChannel:
     def __init__(self, cid: str):
         self.id = int(cid)
@@ -34,8 +40,7 @@ class DummyChannel:
         self.messages.append(msg)
 
 
-@pytest.mark.asyncio
-async def test_start_survey_without_steps(monkeypatch):
+def test_start_survey_without_steps(monkeypatch):
     # Stub config module
     class DummyLogger:
         def info(self, *a, **k):
@@ -72,6 +77,12 @@ async def test_start_survey_without_steps(monkeypatch):
     notion_stub = types.ModuleType("services.notion_todos")
     notion_stub.Notion_todos = object
     monkeypatch.setitem(sys.modules, "services.notion_todos", notion_stub)
+    survey_stub = types.ModuleType("services.survey")
+    survey_stub.SurveyFlow = object
+    monkeypatch.setitem(sys.modules, "services.survey", survey_stub)
+    webhook_stub = types.ModuleType("services.webhook")
+    webhook_stub.WebhookService = object
+    monkeypatch.setitem(sys.modules, "services.webhook", webhook_stub)
 
     # Import survey module after stubbing
     spec = importlib.util.spec_from_file_location(
@@ -102,7 +113,7 @@ async def test_start_survey_without_steps(monkeypatch):
     channel = DummyChannel(channel_id)
 
     async def fake_fetch_channel(cid):
-        assert cid == channel_id
+        assert str(cid) == channel_id
         return channel
 
     bot = types.SimpleNamespace(fetch_channel=fake_fetch_channel)
@@ -112,7 +123,101 @@ async def test_start_survey_without_steps(monkeypatch):
 
     monkeypatch.setattr(survey_cmd, "finish_survey", fake_finish)
 
-    await survey_cmd.handle_start_daily_survey(bot, user_id, channel_id, session_id)
+    asyncio.run(
+        survey_cmd.handle_start_daily_survey(bot, user_id, channel_id, session_id)
+    )
 
     assert called["payload"] == expected
     assert channel.messages == [Strings.SURVEY_COMPLETE_MESSAGE]
+
+
+def test_start_survey_no_required_steps(monkeypatch):
+    class DummyLogger:
+        def info(self, *a, **k):
+            pass
+
+        debug = warning = error = info
+
+    config_stub = types.ModuleType("config")
+    config_stub.ViewType = object
+    config_stub.logger = DummyLogger()
+    config_stub.Strings = types.SimpleNamespace(
+        SURVEY_COMPLETE_MESSAGE="Всі данні внесені. Дякую!",
+        SURVEY_START_ERROR="Сталася помилка",
+    )
+    config_stub.Config = types.SimpleNamespace()
+    # SURVEY_FLOW excludes returned steps
+    config_stub.constants = types.SimpleNamespace(SURVEY_FLOW=["workload_today"])
+    monkeypatch.setitem(sys.modules, "config", config_stub)
+
+    services_stub = types.ModuleType("services")
+    services_stub.__path__ = []
+    created = {}
+
+    def create_survey(u, c, s, sess):
+        created["steps"] = s
+        return types.SimpleNamespace(user_id=u, channel_id=c, steps=s, session_id=sess, current_index=0)
+
+    services_stub.survey_manager = types.SimpleNamespace(
+        get_survey=lambda _cid: None,
+        create_survey=create_survey,
+        remove_survey=lambda _cid: None,
+    )
+    services_stub.webhook_service = types.SimpleNamespace(send_webhook_with_retry=None)
+    services_stub.session_manager = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "services", services_stub)
+    notion_stub = types.ModuleType("services.notion_todos")
+    notion_stub.Notion_todos = object
+    monkeypatch.setitem(sys.modules, "services.notion_todos", notion_stub)
+    survey_stub = types.ModuleType("services.survey")
+    survey_stub.SurveyFlow = object
+    monkeypatch.setitem(sys.modules, "services.survey", survey_stub)
+    webhook_stub = types.ModuleType("services.webhook")
+    webhook_stub.WebhookService = object
+    monkeypatch.setitem(sys.modules, "services.webhook", webhook_stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "discord_bot.commands.survey", ROOT / "discord_bot" / "commands" / "survey.py"
+    )
+    survey_cmd = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(survey_cmd)
+    Strings = config_stub.Strings
+
+    payload = load_payload_example("check_channel Command Payload")
+    channel_id = "123"
+    user_id = "321"
+    session_id = f"{channel_id}_{user_id}"
+    expected = dict(payload)
+    expected["channelId"] = channel_id
+    expected["sessionId"] = session_id
+
+    response = load_check_channel_nonmatching_response()
+    called = {}
+
+    async def fake_send_webhook(target, payload_arg, headers):
+        called["payload"] = payload_arg
+        return True, response
+
+    monkeypatch.setattr(
+        survey_cmd.webhook_service, "send_webhook_with_retry", fake_send_webhook
+    )
+    channel = DummyChannel(channel_id)
+
+    async def fake_fetch_channel(cid):
+        assert str(cid) == channel_id
+        return channel
+
+    bot = types.SimpleNamespace(fetch_channel=fake_fetch_channel)
+
+    async def fake_finish(bot_arg, channel_arg, survey_arg):
+        await channel_arg.send(Strings.SURVEY_COMPLETE_MESSAGE)
+
+    monkeypatch.setattr(survey_cmd, "finish_survey", fake_finish)
+
+    asyncio.run(
+        survey_cmd.handle_start_daily_survey(bot, user_id, channel_id, session_id)
+    )
+
+    assert called["payload"] == expected
+    assert channel.messages == [Strings.SURVEY_COMPLETE_MESSAGE]
+    assert created["steps"] == []


### PR DESCRIPTION
## Summary
- finish survey and fetch Notion tasks even when channel steps don't match required flow
- add check_channel sample response and tests for no-required-step scenario
- refactor repeated minimal-survey logic into a reusable helper

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'databases')*
- `pytest tests/test_survey_start.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1c71157d0833194c7c440eb6be7a8