### PR TITLE
Handle "Nothing" day off lists

### DIFF
--- a/services/cmd/day_off.py
+++ b/services/cmd/day_off.py
@@ -38,10 +38,16 @@ async def handle(payload: Dict[str, Any]) -> str:
             payload.get("result", {}).get("value")
             or payload.get("result", {}).get("daysSelected")
         )
+        if isinstance(value, dict) and "values" in value:
+            value = value.get("values")
         step = payload.get("command")
         if step == "survey":
             step = payload.get("result", {}).get("stepName")
-        if value == "Nothing" or not value:
+        if (
+            value == "Nothing"
+            or value == ["Nothing"]
+            or not value
+        ):
             await _mark_step(payload.get("channelId", ""), step)
             log.info("done", extra={"output": "Записав! Вихідних нема"})
             return "Записав! Вихідних нема"

--- a/tests/test_day_off_handler.py
+++ b/tests/test_day_off_handler.py
@@ -123,6 +123,33 @@ async def test_no_dates(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_with_nothing(tmp_path, monkeypatch):
+    log = tmp_path / "list_nothing_log.txt"
+    log.write_text("Input: ['Nothing']\n")
+
+    cal = DummyCalendar()
+    steps = DummySteps()
+    monkeypatch.setattr(day_off, "calendar", cal)
+    monkeypatch.setattr(day_off, "_steps_db", steps)
+
+    payload = load_payload_example("Day Off Slash Command Payload (e.g., /day_off_nextweek)")
+    payload["command"] = "day_off_thisweek"
+    payload["result"]["value"] = ["Nothing"]
+    payload["author"] = load_author()
+    payload["channelId"] = "123"
+
+    with open(log, "a") as f:
+        f.write("Step: handle\n")
+    out = await day_off.handle(payload)
+    with open(log, "a") as f:
+        f.write(f"Output: {out}\n")
+
+    assert not cal.calls
+    assert steps.calls == [("123", "day_off_thisweek", True)]
+    assert out == "Записав! Вихідних нема"
+
+
+@pytest.mark.asyncio
 async def test_one_date(tmp_path, monkeypatch):
     log = tmp_path / "one_date_log.txt"
     log.write_text("Input: one date\n")


### PR DESCRIPTION
## Summary
- handle day-off payloads that send `{"values": [...]}` structures
- treat `["Nothing"]` the same as "Nothing" and skip calendar writes
- test day off handler with list-based "Nothing" value

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_day_off_handler.py tests/test_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3c77610d8833195e54a2063c17008