### PR TITLE
Clarify start/done log messages with step context

### DIFF
--- a/services/cmd/check_channel.py
+++ b/services/cmd/check_channel.py
@@ -17,7 +17,7 @@ if not hasattr(Config, "DATABASE_URL"):
 
 async def handle(payload: Dict[str, Any], repo: Optional[SurveyStepsDB] = None) -> Dict[str, Any]:
     """Return pending survey steps for the channel or an error message."""
-    log = get_logger()
+    log = get_logger("check_channel", payload)
     try:
         db = repo
         if db is None:
@@ -31,10 +31,11 @@ async def handle(payload: Dict[str, Any], repo: Optional[SurveyStepsDB] = None) 
         )
         records = await db.fetch_week(payload["channelId"], start)
         steps = [r["step_name"] for r in records if not r["completed"]]
-        log.info("pending steps", extra={"steps": steps})
-        return {"output": True, "steps": list(dict.fromkeys(steps))}
+        result = {"output": True, "steps": list(dict.fromkeys(steps))}
+        log.info("done check_channel", extra={"steps": result["steps"]})
+        return result
     except Exception:
-        log.exception("check_channel failed")
+        log.exception("failed check_channel")
         return {
             "output": False,
             "message": "Спробуй трохи піздніше. Я тут пораюсь по хаті.",

--- a/services/cmd/connects_thisweek.py
+++ b/services/cmd/connects_thisweek.py
@@ -17,7 +17,7 @@ ERROR_MESSAGE = "Спробуй трохи піздніше. Я тут пора�
 
 async def handle(payload: Dict[str, Any]) -> str:
     """Record weekly connects and update optional profile stats."""
-    log = get_logger()
+    log = get_logger("connects_thisweek", payload)
     try:
         connects = int(payload["result"]["connects"])
         log.debug("parsed connects", extra={"connects": connects})
@@ -52,10 +52,12 @@ async def handle(payload: Dict[str, Any]) -> str:
                 log.exception("update profile stats failed")
         await notion.close()
 
-        return (
+        result = (
             f"Записав! Upwork connects: залишилось {connects} на цьому тиждні."
         )
+        log.info("done connects_thisweek", extra={"output": result})
+        return result
     except Exception:
-        log.exception("connects_thisweek failed")
+        log.exception("failed connects_thisweek")
         return ERROR_MESSAGE
 

--- a/services/cmd/register.py
+++ b/services/cmd/register.py
@@ -9,7 +9,7 @@ _notio = NotionConnector()
 
 async def handle(payload: Dict[str, Any]) -> str:
     """Handle the ``!register`` prefix command."""
-    log = get_logger()
+    log = get_logger("register", payload)
     name = payload.get("result", {}).get("text", "").strip()
     user_id = payload.get("userId", "")
     channel_id = payload.get("channelId", "")
@@ -33,8 +33,9 @@ async def handle(payload: Dict[str, Any]) -> str:
             log.info("channel taken", extra={"discord_id": page.get("discord_id")})
             return "Канал вже зареєстрований на когось іншого."
         await _notio.update_team_directory_ids(page.get("id", ""), user_id, channel_id)
-        log.info("registered", extra={"page_id": page.get("id", "")})
-        return f"Канал успішно зареєстровано на {name}"
+        result_msg = f"Канал успішно зареєстровано на {name}"
+        log.info("done register", extra={"page_id": page.get("id", ""), "output": result_msg})
+        return result_msg
     except Exception:
-        log.exception("register failed")
+        log.exception("failed register")
         return "Спробуй трохи піздніше. Я тут пораюсь по хаті."

--- a/services/cmd/unregister.py
+++ b/services/cmd/unregister.py
@@ -7,7 +7,7 @@ _notio = NotionConnector()
 
 
 async def handle(payload: Dict[str, Any]) -> str:
-    log = get_logger()
+    log = get_logger("unregister", payload)
     channel_id = payload.get("channelId", "")
     try:
         log.debug("lookup channel", extra={"channel_id": channel_id})
@@ -20,8 +20,9 @@ async def handle(payload: Dict[str, Any]) -> str:
             )
         page_id = page[0]["id"]
         await _notio.clear_team_directory_ids(page_id)
-        log.info("unregistered", extra={"page_id": page_id})
-        return "Готово. Тепер цей канал не зареєстрований ні на кого."
+        result = "Готово. Тепер цей канал не зареєстрований ні на кого."
+        log.info("done unregister", extra={"page_id": page_id, "output": result})
+        return result
     except Exception:
-        log.exception("unregister failed")
+        log.exception("failed unregister")
         return "Спробуй трохи піздніше. Я тут пораюсь по хаті."

--- a/services/cmd/vacation.py
+++ b/services/cmd/vacation.py
@@ -48,7 +48,7 @@ def _fmt(date_str: str) -> str:
 
 async def handle(payload: Dict[str, Any]) -> str:
     """Handle the vacation command."""
-    log = get_logger()
+    log = get_logger("vacation", payload)
     try:
         result = payload.get("result", {})
         start_raw = result["start_date"]
@@ -76,7 +76,9 @@ async def handle(payload: Dict[str, Any]) -> str:
         finally:
             await db.close()
 
-        return f"Записав! Відпустка: {_fmt(start_raw)}—{_fmt(end_raw)}."
+        result_msg = f"Записав! Відпустка: {_fmt(start_raw)}—{_fmt(end_raw)}."
+        log.info("done vacation", extra={"output": result_msg})
+        return result_msg
     except Exception:
-        log.exception("vacation failed")
+        log.exception("failed vacation")
         return "Спробуй трохи піздніше. Я тут пораюсь по хаті."

--- a/services/cmd/workload_nextweek.py
+++ b/services/cmd/workload_nextweek.py
@@ -27,7 +27,7 @@ def template(hours: Union[int, float]) -> str:
 
 async def handle(payload: Dict[str, Any]) -> str:
     """Handle the `workload_nextweek` command."""
-    log = get_logger()
+    log = get_logger("workload_nextweek", payload)
     try:
         result = payload.get("result", {})
         hours_raw = result.get("value", result.get("workload"))
@@ -43,7 +43,9 @@ async def handle(payload: Dict[str, Any]) -> str:
         db = _ensure_db()
         await db.upsert_step(payload["channelId"], "workload_nextweek", True)
         log.info("step recorded")
-        return template(hours)
+        result_msg = template(hours)
+        log.info("done workload_nextweek", extra={"output": result_msg})
+        return result_msg
     except Exception:
-        log.exception("workload_nextweek failed")
+        log.exception("failed workload_nextweek")
         return ERROR_MSG

--- a/services/cmd/workload_today.py
+++ b/services/cmd/workload_today.py
@@ -58,7 +58,7 @@ ERROR_MSG = "Спробуй трохи піздніше. Я тут пораюс�
 async def handle(payload: Dict[str, Any]) -> str:
     """Handle the ``workload_today`` command."""
 
-    log = get_logger()
+    log = get_logger("workload_today", payload)
     try:
         result = payload.get("result", {})
         hours_raw = result.get("value", result.get("workload"))
@@ -101,12 +101,14 @@ async def handle(payload: Dict[str, Any]) -> str:
 
         day_acc = DAY_ACC[idx]
         day_gen = DAY_GEN[idx]
-        return (
+        result_msg = (
             "Записав! \n"
             f"Заплановане навантаження у {day_acc}: {hours} год. \n"
             f"В щоденнику з понеділка до {day_gen}: {fact} год.\n"
             f"Капасіті на цей тиждень: {capacity} год."
         )
+        log.info("done workload_today", extra={"output": result_msg})
+        return result_msg
     except (NotionError, KeyError, ValueError, TypeError, IndexError):
-        log.exception("workload_today failed")
+        log.exception("failed workload_today")
         return ERROR_MSG

--- a/services/logging_utils.py
+++ b/services/logging_utils.py
@@ -47,15 +47,15 @@ def wrap_handler(step_name: str, func: Callable[[Dict[str, Any]], Awaitable[Any]
         }
         token = current_context.set(ctx)
         log = get_logger(step_name, payload)
-        log.info("start")
+        log.info(f"start {step_name}")
         log.debug("payload", extra={"payload": payload})
         try:
             result = await func(payload)
             log.debug("response ready", extra={"output": result})
-            log.info("done")
+            log.info(f"done {step_name}")
             return result
         except Exception:
-            log.exception("failed")
+            log.exception("failed %s", step_name)
             raise
         finally:
             current_context.reset(token)

--- a/services/router.py
+++ b/services/router.py
@@ -63,12 +63,12 @@ async def dispatch(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
     token = current_context.set(ctx)
     log = get_logger("router.dispatch", payload)
-    log.info("start")
+    log.info("start router.dispatch")
     log.debug("payload", extra={"payload": payload})
 
     def finalize(resp: Dict[str, Any]) -> Dict[str, Any]:
         log.debug("response ready", extra={"output": resp})
-        log.info("done")
+        log.info("done router.dispatch")
         current_context.reset(token)
         return resp
 
@@ -154,5 +154,5 @@ async def dispatch(payload: Dict[str, Any]) -> Dict[str, Any]:
             return finalize({"output": "Спробуй трохи піздніше. Я тут пораюсь по хаті."})
         return finalize({"output": output})
     except Exception:  # pragma: no cover - defensive
-        log.exception("failed")
+        log.exception("failed router.dispatch")
         return finalize({"output": "Спробуй трохи піздніше. Я тут пораюсь по хаті."})

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -108,9 +108,9 @@ async def test_logging_success(tmp_path, monkeypatch, caplog):
         f.write(f"Output: {result}\n")
 
     assert result == {"output": "ok"}
-    assert any(r.message == "start" and r.step_name == "router.dispatch" for r in caplog.records)
-    assert any(r.message == "done" and r.step_name == "router.dispatch" for r in caplog.records)
-    assert any(r.message == "done" and r.step_name == "dummy" for r in caplog.records)
+    assert any(r.message == "start router.dispatch" for r in caplog.records)
+    assert any(r.message == "done router.dispatch" for r in caplog.records)
+    assert any(r.message == "done dummy" for r in caplog.records)
     assert any(r.session_id == "123_321" for r in caplog.records)
     assert any(r.user == "321" for r in caplog.records)
     assert any(r.channel == "123" for r in caplog.records)
@@ -143,7 +143,7 @@ async def test_logging_error(tmp_path, monkeypatch, caplog):
         f.write(f"Output: {result}\n")
 
     assert result == {"output": "Спробуй трохи піздніше. Я тут пораюсь по хаті."}
-    assert any(r.message == "failed" and r.step_name == "boom" for r in caplog.records)
+    assert any(r.message == "failed boom" for r in caplog.records)
     assert any(r.session_id == "123_321" for r in caplog.records)
     assert any(r.user == "321" for r in caplog.records)
     assert any(r.channel == "123" for r in caplog.records)


### PR DESCRIPTION
## Summary
- include handler name in generic start/done logs
- improve router and day-off handler logging
- adjust logging tests for new messages
- extend step-aware logging across all command handlers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3ce7e0734833198898f2fe5bb1b21